### PR TITLE
Fix bug causing dates to be parsed incorrectly

### DIFF
--- a/server/controllers/inputsValidation.test.ts
+++ b/server/controllers/inputsValidation.test.ts
@@ -46,6 +46,7 @@ describe('validateDateTo', () => {
       { inputTo: '01/01/a', inputFrom: '', expected: errors.valid },
       { inputTo: '01/01/2150', inputFrom: '', expected: errors.future },
       { inputTo: '01/01/2021', inputFrom: '01/01/2022', expected: errors.after },
+      { inputTo: '30/01/2021', inputFrom: '01/01/2022', expected: errors.after },
     ]
     testCases.forEach(testCase => {
       const actual = InputsValidation.validateDateRange(testCase.inputFrom, testCase.inputTo)

--- a/server/controllers/inputsValidation.ts
+++ b/server/controllers/inputsValidation.ts
@@ -55,7 +55,7 @@ export default class InputsValidation {
     if (parsedDate > new Date()) {
       throw new ValidationError(`${fieldName} must not be in the future`)
     }
-    return new Date(dateDay, dateMonth - 1, dateYear)
+    return parsedDate
   }
 
   static validateCaseReference(caseReference: string): string {


### PR DESCRIPTION
### Context

The javascript Date() constructor expects date arguments in the order YYYY-MM-DD. 

A typo meant that we were providing arguments as DD-MM-YYYY. The docs state that when a year between 0-99 is used, then the year is assumed to be 1900+year. This meant for example that when a user inputted 30-01-2000, the year was read in our system as 1930. 

There are additional confounding factors, such as that the Date() function will also accept days over 31 and increment the months and years accordingly. 

The result was that an incorrect validation error stating that the "Date From" date was after the "Date To" date was being provided. This bug is most replicable with dates where the day in the "Date From" date is higher than that of the "Date To" date, e.g., 30/01/2020 and 01/01/2022. 

It is not replicable in every case where the day is higher in the "Date From" date because of the aforementioned way that the Date() function adjusts for values higher than that expected (i.e., if the difference in year is great enough, it may offset the effect of the difference in days.)

### Changes proposed in this PR

- Pass the values into the Date() function in the correct order
- Add a relevant test