### PR TITLE
Create confirmation page

### DIFF
--- a/integration_tests/e2e/confirmation.cy.ts
+++ b/integration_tests/e2e/confirmation.cy.ts
@@ -1,0 +1,21 @@
+import Page from '../pages/page'
+import AuthSignInPage from '../pages/authSignIn'
+
+context('Confirmation', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubManageUser')
+  })
+
+  // All pages direct users to auth
+  it('Redirects to auth if requested by unauthenticated user', () => {
+    cy.visit('/confirmation')
+    Page.verifyOnPage(AuthSignInPage)
+  })
+
+  it('Renders for authenticated users', () => {
+    cy.signIn()
+    cy.visit('/confirmation')
+  })
+})

--- a/integration_tests/e2e/confirmation.cy.ts
+++ b/integration_tests/e2e/confirmation.cy.ts
@@ -1,5 +1,6 @@
 import Page from '../pages/page'
 import AuthSignInPage from '../pages/authSignIn'
+import ConfirmationPage from '../pages/confirmation'
 
 context('Confirmation', () => {
   beforeEach(() => {
@@ -8,7 +9,6 @@ context('Confirmation', () => {
     cy.task('stubManageUser')
   })
 
-  // All pages direct users to auth
   it('Redirects to auth if requested by unauthenticated user', () => {
     cy.visit('/confirmation')
     Page.verifyOnPage(AuthSignInPage)
@@ -17,5 +17,27 @@ context('Confirmation', () => {
   it('Renders for authenticated users', () => {
     cy.signIn()
     cy.visit('/confirmation')
+  })
+
+  it('Displays confirmation panel', () => {
+    cy.signIn()
+    cy.visit('/confirmation')
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+    confirmationPage.confirmationPanel().should('exist')
+  })
+
+  it('Displays next steps', () => {
+    cy.signIn()
+    cy.visit('/confirmation')
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+    confirmationPage.nextSteps().should('exist')
+  })
+
+  it('Displays link to view reports page', () => {
+    cy.signIn()
+    cy.visit('/confirmation')
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+    confirmationPage.viewReportsLink().should('exist')
+    confirmationPage.viewReportsLink().should('have.attr', 'href', '/reports')
   })
 })

--- a/integration_tests/e2e/summary.cy.ts
+++ b/integration_tests/e2e/summary.cy.ts
@@ -137,4 +137,12 @@ context('Summary', () => {
       'By accepting these details you are confirming that, to the best of your knowledge, these details are correct.',
     )
   })
+
+  it('Redirects to /confirmation on clicking submit button', () => {
+    cy.signIn()
+    cy.visit('/summary')
+    const summaryPage = Page.verifyOnPage(SummaryPage)
+    summaryPage.acceptConfirmButton().click()
+    cy.url().should('to.match', /confirmation$/)
+  })
 })

--- a/integration_tests/pages/confirmation.ts
+++ b/integration_tests/pages/confirmation.ts
@@ -1,0 +1,13 @@
+import Page, { PageElement } from './page'
+
+export default class ConfirmationPage extends Page {
+  constructor() {
+    super('has been submitted')
+  }
+
+  confirmationPanel = (): PageElement => cy.get('#confirmation-panel')
+
+  nextSteps = (): PageElement => cy.get('#next-steps')
+
+  viewReportsLink = (): PageElement => cy.get('#view-reports')
+}

--- a/server/controllers/confirmationController.test.ts
+++ b/server/controllers/confirmationController.test.ts
@@ -1,0 +1,32 @@
+import type { Request, Response } from 'express'
+import ConfirmationController from './confirmationController'
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('getConfirmation', () => {
+  // @ts-expect-error stubbing res.render
+  const res: Response = {
+    render: jest.fn(),
+  }
+
+  test('renders a response with session data', async () => {
+    const req: Request = {
+      // @ts-expect-error stubbing session
+      session: {
+        userData: {
+          caseReference: 'ExampleCaseReference',
+        },
+      },
+    }
+    await ConfirmationController.getConfirmation(req, res)
+    expect(res.render).toHaveBeenCalled()
+    expect(res.render).toBeCalledWith(
+      'pages/confirmation',
+      expect.objectContaining({
+        caseReference: req.session.userData.caseReference,
+      }),
+    )
+  })
+})

--- a/server/controllers/confirmationController.ts
+++ b/server/controllers/confirmationController.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express'
+
+export default class ConfirmationController {
+  static getConfirmation(req: Request, res: Response) {
+    const userData = req.session.userData ?? {}
+
+    res.render('pages/confirmation', {
+      caseReference: userData.caseReference,
+    })
+  }
+}

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -66,3 +66,14 @@ describe('POST /serviceselection', () => {
       })
   })
 })
+
+describe('GET /confirmation', () => {
+  it('should render confirmation page', () => {
+    return request(app)
+      .get('/confirmation')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('has been submitted')
+      })
+  })
+})

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import type { Services } from '../services'
 import InputsController from '../controllers/inputsController'
 import ServiceSelectionController from '../controllers/serviceSelectionController'
 import SummaryController from '../controllers/summaryController'
+import ConfirmationController from '../controllers/confirmationController'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(service: Services): Router {
@@ -24,9 +25,7 @@ export default function routes(service: Services): Router {
 
   router.post('/serviceselection', ServiceSelectionController.selectServices)
 
-  get('/confirmation', (req, res, next) => {
-    res.render('pages/confirmation')
-  })
+  get('/confirmation', ConfirmationController.getConfirmation)
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -24,5 +24,9 @@ export default function routes(service: Services): Router {
 
   router.post('/serviceselection', ServiceSelectionController.selectServices)
 
+  get('/confirmation', (req, res, next) => {
+    res.render('pages/confirmation')
+  })
+
   return router
 }

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -1,0 +1,10 @@
+{% extends "../partials/layout.njk" %}
+
+{% block content %}
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          Your report has been submitted 
+        </h1>
+    </legend>
+
+  {% endblock %}

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -4,12 +4,11 @@
 
 {% block content %}
 
-    {{ govukPanel({
-      titleText: "Your report has been submitted",
-      attributes: {
-        "id": "confirmation-panel"
-      }
-    }) }}
+    <div class="govuk-panel govuk-panel--confirmation" id="confirmation-panel">
+      <h1 class="govuk-panel__title">
+        Your report request for {{ caseReference }} has been submitted
+      </h1>
+    </div>
 
     <section id="next-steps">
       <h2 class="govuk-heading-m">What happens next</h2>

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -1,10 +1,22 @@
 {% extends "../partials/layout.njk" %}
 
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
 {% block content %}
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading">
-          Your report has been submitted 
-        </h1>
-    </legend>
+
+    {{ govukPanel({
+      titleText: "Your report has been submitted",
+      attributes: {
+        "id": "confirmation-panel"
+      }
+    }) }}
+
+    <section id="next-steps">
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p class="govuk-body">Lorem ipsum sit dolor et amet - content to be confirmed.</p>
+      <p class="govuk-body">You will not get an email notification about this report. But you can check its progress on the completed reports page.</p>
+    </section>
+
+    <a href="/reports" class="govuk-body govuk-link" id="view-reports">View completed reports.</a>
 
   {% endblock %}

--- a/server/views/pages/summary.njk
+++ b/server/views/pages/summary.njk
@@ -106,7 +106,8 @@
   {{ govukButton({
     text: "Accept and create report",
     id: "accept-confirm",
-    type: "submit"
+    type: "submit",
+    href: "/confirmation"
   }) }}
 
   {% endblock %}


### PR DESCRIPTION
## Changes proposed in this pull request

* Add confirmation page, as per [SAR45](https://dsdmoj.atlassian.net/browse/SR-45).
* Use SAR case reference number as an interim identifier on the confirmation page (as opposed to subject name in the initial design) until person search/specification is implemented.
* Link from the summary page to the confirmation page.

## Next steps

* Replace case reference with subject name (or other identifier if preferred) when this part of the user journey is built.
* Update "View completed reports" link when this page is built.