### PR TITLE
Add validation for subject ID

### DIFF
--- a/integration_tests/e2e/subjectId.cy.ts
+++ b/integration_tests/e2e/subjectId.cy.ts
@@ -1,6 +1,7 @@
 import Page from '../pages/page'
 import AuthSignInPage from '../pages/authSignIn'
 import SubjectIdPage from '../pages/subjectId'
+import InputsPage from '../pages/inputs'
 
 context('SubjectId', () => {
   beforeEach(() => {
@@ -51,6 +52,7 @@ context('SubjectId', () => {
     let subjectIdPage = Page.verifyOnPage(SubjectIdPage)
     subjectIdPage.idTextBox().clear().type('A1111AA')
     subjectIdPage.continueButton().click()
+    Page.verifyOnPage(InputsPage)
     cy.visit('/subject-id')
     subjectIdPage = Page.verifyOnPage(SubjectIdPage)
     subjectIdPage.idTextBox().should('have.value', 'A1111AA')

--- a/integration_tests/e2e/subjectId.cy.ts
+++ b/integration_tests/e2e/subjectId.cy.ts
@@ -33,7 +33,7 @@ context('SubjectId', () => {
     subjectIdPage.continueButton().should('exist')
   })
 
-  it('Submits subject id user input and redirects to /inputs', () => {
+  it('Submits valid subject id user input and redirects to /inputs', () => {
     cy.signIn()
     cy.visit('/subject-id')
     const subjectIdPage = Page.verifyOnPage(SubjectIdPage)
@@ -48,11 +48,35 @@ context('SubjectId', () => {
   it('Persists user inputs when returning to page', () => {
     cy.signIn()
     cy.visit('/subject-id')
-    let inputsPage = Page.verifyOnPage(SubjectIdPage)
-    inputsPage.idTextBox().clear().type('A1111AA')
-    inputsPage.continueButton().click()
+    let subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.idTextBox().clear().type('A1111AA')
+    subjectIdPage.continueButton().click()
     cy.visit('/subject-id')
-    inputsPage = Page.verifyOnPage(SubjectIdPage)
-    inputsPage.idTextBox().should('have.value', 'A1111AA')
+    subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.idTextBox().should('have.value', 'A1111AA')
+  })
+
+  it('Does not allow subject ID to be empty', () => {
+    cy.signIn()
+    cy.visit('/subject-id')
+    let subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.continueButton().click()
+    cy.wait('@saveSubjectId')
+    cy.url().should('to.match', /subject-id$/)
+    subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.errorSummaryBox().should('exist')
+  })
+
+  it('Does not allow invalid input', () => {
+    const invalidSubjectId = 'not-a-nomis-or-ndelius-id'
+    cy.signIn()
+    cy.visit('/subject-id')
+    let subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.idTextBox().clear().type(invalidSubjectId)
+    subjectIdPage.continueButton().click()
+    cy.wait('@saveSubjectId')
+    cy.url().should('to.match', /subject-id$/)
+    subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.errorSummaryBox().should('exist')
   })
 })

--- a/integration_tests/pages/subjectId.ts
+++ b/integration_tests/pages/subjectId.ts
@@ -12,4 +12,6 @@ export default class SubjectIdPage extends Page {
   additionalInformation = (): PageElement => cy.get('#additional-information')
 
   continueButton = (): PageElement => cy.get('#subject-id-continue')
+
+  errorSummaryBox = (): PageElement => cy.get('.govuk-error-summary')
 }

--- a/server/@types/userdata.d.ts
+++ b/server/@types/userdata.d.ts
@@ -1,6 +1,5 @@
 export interface UserData {
-  nomisId: string
-  ndeliusId: string
+  subjectId: string
   dateFrom: string
   dateTo: string
   caseReference: string

--- a/server/@types/userdata.d.ts
+++ b/server/@types/userdata.d.ts
@@ -1,5 +1,6 @@
 export interface UserData {
-  subjectId: string
+  nomisId: string
+  ndeliusId: string
   dateFrom: string
   dateTo: string
   caseReference: string

--- a/server/controllers/subjectIdController.test.ts
+++ b/server/controllers/subjectIdController.test.ts
@@ -29,12 +29,35 @@ describe('getSubjectId', () => {
   })
 
   describe('when a user returns within a session', () => {
-    test('renders a response with subject ID entered previously in session', () => {
+    describe('when the subject ID that was previously entered was a NOMIS ID', () => {
+      test('renders a response with subject ID populated', () => {
+        const req: Request = {
+          // @ts-expect-error stubbing session
+          session: {
+            userData: {
+              nomisId: 'A1111AA',
+            },
+          },
+        }
+
+        SubjectIdController.getSubjectId(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/subjectid',
+          expect.objectContaining({
+            subjectId: req.session.userData.nomisId,
+          }),
+        )
+      })
+    })
+  })
+
+  describe('when the subject ID that was previously entered was a nDelius ID', () => {
+    test('renders a response with subject ID populated', () => {
       const req: Request = {
         // @ts-expect-error stubbing session
         session: {
           userData: {
-            subjectId: 'A1111AA',
+            ndeliusId: 'A1111AA',
           },
         },
       }
@@ -43,7 +66,7 @@ describe('getSubjectId', () => {
       expect(res.render).toBeCalledWith(
         'pages/subjectid',
         expect.objectContaining({
-          subjectId: req.session.userData.subjectId,
+          subjectId: req.session.userData.ndeliusId,
         }),
       )
     })
@@ -51,45 +74,160 @@ describe('getSubjectId', () => {
 })
 
 describe('saveSubjectId', () => {
-  const baseReq: Request = {
-    // @ts-expect-error stubbing session
-    session: {
-      userData: {},
-    },
-    body: {
-      subjectId: 'A1111AA',
-    },
-  }
-
   // @ts-expect-error stubbing res.render
   const res: Response = {
     redirect: jest.fn(),
+    render: jest.fn(),
   }
 
-  test('persists values to the session', () => {
-    SubjectIdController.saveSubjectId(baseReq, res)
-    expect(baseReq.session.userData.subjectId).toBe('A1111AA')
+  describe('when a valid Subject ID is provided', () => {
+    describe('when the subject ID is a NOMIS ID', () => {
+      const baseReqWithNomisId: Request = {
+        // @ts-expect-error stubbing session
+        session: {
+          userData: {},
+        },
+        body: {
+          subjectId: 'A1111AA',
+        },
+      }
+
+      test('saves as nomisId', () => {
+        SubjectIdController.saveSubjectId(baseReqWithNomisId, res)
+        expect(baseReqWithNomisId.session.userData.nomisId).toBe('A1111AA')
+      })
+
+      test('redirects to the next page in the user journey', () => {
+        SubjectIdController.saveSubjectId(baseReqWithNomisId, res)
+        expect(res.redirect).toHaveBeenCalled()
+        expect(res.redirect).toBeCalledWith('/inputs')
+      })
+
+      describe('when a user has already provided a subject ID in the session', () => {
+        test('overwrites NOMIS ID if previous subject ID was a NOMIS ID', () => {
+          const req: Request = {
+            ...baseReqWithNomisId,
+            // @ts-expect-error stubbing session
+            session: {
+              userData: {
+                nomisId: 'Z9999ZZ',
+              },
+            },
+          }
+          SubjectIdController.saveSubjectId(req, res)
+          expect(req.session.userData.nomisId).toBe('A1111AA')
+          expect(req.session.userData.ndeliusId).toBe(null)
+          expect(res.redirect).toHaveBeenCalled()
+          expect(res.redirect).toBeCalledWith('/inputs')
+        })
+
+        test('saves new NOMIS ID and discards old nDelius ID if previous subject ID was a nDelius ID', () => {
+          const req: Request = {
+            ...baseReqWithNomisId,
+            // @ts-expect-error stubbing session
+            session: {
+              userData: {
+                nDelius: 'Z999999',
+              },
+            },
+          }
+          SubjectIdController.saveSubjectId(req, res)
+          expect(req.session.userData.nomisId).toBe('A1111AA')
+          expect(req.session.userData.ndeliusId).toBe(null)
+          expect(res.redirect).toHaveBeenCalled()
+          expect(res.redirect).toBeCalledWith('/inputs')
+        })
+      })
+    })
+
+    describe('when the subject ID is a nDelius ID', () => {
+      const baseReqWithNdeliusId: Request = {
+        // @ts-expect-error stubbing session
+        session: {
+          userData: {},
+        },
+        body: {
+          subjectId: 'A111111',
+        },
+      }
+      test('saves as ndeliusId', () => {
+        SubjectIdController.saveSubjectId(baseReqWithNdeliusId, res)
+        expect(baseReqWithNdeliusId.session.userData.ndeliusId).toBe('A111111')
+      })
+
+      test('redirects to the next page in the user journey', () => {
+        SubjectIdController.saveSubjectId(baseReqWithNdeliusId, res)
+        expect(res.redirect).toHaveBeenCalled()
+        expect(res.redirect).toBeCalledWith('/inputs')
+      })
+
+      describe('when a user has already provided a subject ID in the session', () => {
+        test('overwrites nDelius ID if previous subject ID was a nDelius ID', () => {
+          const req: Request = {
+            ...baseReqWithNdeliusId,
+            // @ts-expect-error stubbing session
+            session: {
+              userData: {
+                ndeiusId: 'Z999999',
+              },
+            },
+          }
+          SubjectIdController.saveSubjectId(req, res)
+          expect(req.session.userData.ndeliusId).toBe('A111111')
+          expect(req.session.userData.nomisId).toBe(null)
+          expect(res.redirect).toHaveBeenCalled()
+          expect(res.redirect).toBeCalledWith('/inputs')
+        })
+
+        test('saves new nDelius ID and discards old NOMIS ID if previous subject ID was a NOMIS ID', () => {
+          const req: Request = {
+            ...baseReqWithNdeliusId,
+            // @ts-expect-error stubbing session
+            session: {
+              userData: {
+                nomisId: 'Z9999ZZ',
+              },
+            },
+          }
+          SubjectIdController.saveSubjectId(req, res)
+          expect(req.session.userData.ndeliusId).toBe('A111111')
+          expect(req.session.userData.nomisId).toBe(null)
+          expect(res.redirect).toHaveBeenCalled()
+          expect(res.redirect).toBeCalledWith('/inputs')
+        })
+      })
+    })
   })
 
-  test('redirects to the next page in the user journey', () => {
-    SubjectIdController.saveSubjectId(baseReq, res)
-    expect(res.redirect).toHaveBeenCalled()
-    expect(res.redirect).toBeCalledWith('/inputs')
-  })
-
-  test('overwrites previous session data if present', () => {
-    const req: Request = {
-      ...baseReq,
+  describe('when an invalid Subject ID is provided', () => {
+    const baseReqWithInvalidId: Request = {
       // @ts-expect-error stubbing session
       session: {
-        userData: {
-          subjectId: 'subjectIdToBeOverwritten',
-        },
+        userData: {},
+      },
+      body: {
+        subjectId: 'invalid-subject-id',
       },
     }
-    SubjectIdController.saveSubjectId(req, res)
-    expect(req.session.userData.subjectId).toBe('A1111AA')
-    expect(res.redirect).toHaveBeenCalled()
-    expect(res.redirect).toBeCalledWith('/inputs')
+
+    test('user is returned to the subject ID page', () => {
+      SubjectIdController.saveSubjectId(baseReqWithInvalidId, res)
+      expect(res.render).toBeCalledWith(
+        'pages/subjectid',
+        expect.objectContaining({
+          subjectId: baseReqWithInvalidId.body.subjectId,
+        }),
+      )
+    })
+
+    test('user receives an invalid subject ID error', () => {
+      SubjectIdController.saveSubjectId(baseReqWithInvalidId, res)
+      expect(res.render).toBeCalledWith(
+        'pages/subjectid',
+        expect.objectContaining({
+          subjectIdError: 'Subject ID must be a NOMIS prisoner number or nDelius case reference number',
+        }),
+      )
+    })
   })
 })

--- a/server/controllers/subjectIdController.test.ts
+++ b/server/controllers/subjectIdController.test.ts
@@ -29,35 +29,12 @@ describe('getSubjectId', () => {
   })
 
   describe('when a user returns within a session', () => {
-    describe('when the subject ID that was previously entered was a NOMIS ID', () => {
-      test('renders a response with subject ID populated', () => {
-        const req: Request = {
-          // @ts-expect-error stubbing session
-          session: {
-            userData: {
-              nomisId: 'A1111AA',
-            },
-          },
-        }
-
-        SubjectIdController.getSubjectId(req, res)
-        expect(res.render).toBeCalledWith(
-          'pages/subjectid',
-          expect.objectContaining({
-            subjectId: req.session.userData.nomisId,
-          }),
-        )
-      })
-    })
-  })
-
-  describe('when the subject ID that was previously entered was a nDelius ID', () => {
     test('renders a response with subject ID populated', () => {
       const req: Request = {
         // @ts-expect-error stubbing session
         session: {
           userData: {
-            ndeliusId: 'A1111AA',
+            subjectId: 'A1111AA',
           },
         },
       }
@@ -66,7 +43,7 @@ describe('getSubjectId', () => {
       expect(res.render).toBeCalledWith(
         'pages/subjectid',
         expect.objectContaining({
-          subjectId: req.session.userData.ndeliusId,
+          subjectId: req.session.userData.subjectId,
         }),
       )
     })
@@ -81,126 +58,47 @@ describe('saveSubjectId', () => {
   }
 
   describe('when a valid Subject ID is provided', () => {
-    describe('when the subject ID is a NOMIS ID', () => {
-      const baseReqWithNomisId: Request = {
-        // @ts-expect-error stubbing session
-        session: {
-          userData: {},
-        },
-        body: {
-          subjectId: 'A1111AA',
-        },
-      }
+    const baseReq: Request = {
+      // @ts-expect-error stubbing session
+      session: {
+        userData: {},
+      },
+      body: {
+        subjectId: 'A1111AA',
+      },
+    }
 
-      test('saves as nomisId', () => {
-        SubjectIdController.saveSubjectId(baseReqWithNomisId, res)
-        expect(baseReqWithNomisId.session.userData.nomisId).toBe('A1111AA')
-      })
-
-      test('redirects to the next page in the user journey', () => {
-        SubjectIdController.saveSubjectId(baseReqWithNomisId, res)
-        expect(res.redirect).toHaveBeenCalled()
-        expect(res.redirect).toBeCalledWith('/inputs')
-      })
-
-      describe('when a user has already provided a subject ID in the session', () => {
-        test('overwrites NOMIS ID if previous subject ID was a NOMIS ID', () => {
-          const req: Request = {
-            ...baseReqWithNomisId,
-            // @ts-expect-error stubbing session
-            session: {
-              userData: {
-                nomisId: 'Z9999ZZ',
-              },
-            },
-          }
-          SubjectIdController.saveSubjectId(req, res)
-          expect(req.session.userData.nomisId).toBe('A1111AA')
-          expect(req.session.userData.ndeliusId).toBe(null)
-          expect(res.redirect).toHaveBeenCalled()
-          expect(res.redirect).toBeCalledWith('/inputs')
-        })
-
-        test('saves new NOMIS ID and discards old nDelius ID if previous subject ID was a nDelius ID', () => {
-          const req: Request = {
-            ...baseReqWithNomisId,
-            // @ts-expect-error stubbing session
-            session: {
-              userData: {
-                nDelius: 'Z999999',
-              },
-            },
-          }
-          SubjectIdController.saveSubjectId(req, res)
-          expect(req.session.userData.nomisId).toBe('A1111AA')
-          expect(req.session.userData.ndeliusId).toBe(null)
-          expect(res.redirect).toHaveBeenCalled()
-          expect(res.redirect).toBeCalledWith('/inputs')
-        })
-      })
+    test('saves to session', () => {
+      SubjectIdController.saveSubjectId(baseReq, res)
+      expect(baseReq.session.userData.subjectId).toBe('A1111AA')
     })
 
-    describe('when the subject ID is a nDelius ID', () => {
-      const baseReqWithNdeliusId: Request = {
-        // @ts-expect-error stubbing session
-        session: {
-          userData: {},
-        },
-        body: {
-          subjectId: 'A111111',
-        },
-      }
-      test('saves as ndeliusId', () => {
-        SubjectIdController.saveSubjectId(baseReqWithNdeliusId, res)
-        expect(baseReqWithNdeliusId.session.userData.ndeliusId).toBe('A111111')
-      })
+    test('redirects to the next page in the user journey', () => {
+      SubjectIdController.saveSubjectId(baseReq, res)
+      expect(res.redirect).toHaveBeenCalled()
+      expect(res.redirect).toBeCalledWith('/inputs')
+    })
 
-      test('redirects to the next page in the user journey', () => {
-        SubjectIdController.saveSubjectId(baseReqWithNdeliusId, res)
+    describe('when a user has already provided a subject ID in the session', () => {
+      test('overwrites previous subjec tID', () => {
+        const req: Request = {
+          ...baseReq,
+          // @ts-expect-error stubbing session
+          session: {
+            userData: {
+              subjectId: 'Z9999ZZ',
+            },
+          },
+        }
+        SubjectIdController.saveSubjectId(req, res)
+        expect(req.session.userData.subjectId).toBe('A1111AA')
         expect(res.redirect).toHaveBeenCalled()
         expect(res.redirect).toBeCalledWith('/inputs')
-      })
-
-      describe('when a user has already provided a subject ID in the session', () => {
-        test('overwrites nDelius ID if previous subject ID was a nDelius ID', () => {
-          const req: Request = {
-            ...baseReqWithNdeliusId,
-            // @ts-expect-error stubbing session
-            session: {
-              userData: {
-                ndeiusId: 'Z999999',
-              },
-            },
-          }
-          SubjectIdController.saveSubjectId(req, res)
-          expect(req.session.userData.ndeliusId).toBe('A111111')
-          expect(req.session.userData.nomisId).toBe(null)
-          expect(res.redirect).toHaveBeenCalled()
-          expect(res.redirect).toBeCalledWith('/inputs')
-        })
-
-        test('saves new nDelius ID and discards old NOMIS ID if previous subject ID was a NOMIS ID', () => {
-          const req: Request = {
-            ...baseReqWithNdeliusId,
-            // @ts-expect-error stubbing session
-            session: {
-              userData: {
-                nomisId: 'Z9999ZZ',
-              },
-            },
-          }
-          SubjectIdController.saveSubjectId(req, res)
-          expect(req.session.userData.ndeliusId).toBe('A111111')
-          expect(req.session.userData.nomisId).toBe(null)
-          expect(res.redirect).toHaveBeenCalled()
-          expect(res.redirect).toBeCalledWith('/inputs')
-        })
       })
     })
   })
-
   describe('when an invalid Subject ID is provided', () => {
-    const baseReqWithInvalidId: Request = {
+    const baseReq: Request = {
       // @ts-expect-error stubbing session
       session: {
         userData: {},
@@ -211,17 +109,17 @@ describe('saveSubjectId', () => {
     }
 
     test('user is returned to the subject ID page', () => {
-      SubjectIdController.saveSubjectId(baseReqWithInvalidId, res)
+      SubjectIdController.saveSubjectId(baseReq, res)
       expect(res.render).toBeCalledWith(
         'pages/subjectid',
         expect.objectContaining({
-          subjectId: baseReqWithInvalidId.body.subjectId,
+          subjectId: baseReq.body.subjectId,
         }),
       )
     })
 
     test('user receives an invalid subject ID error', () => {
-      SubjectIdController.saveSubjectId(baseReqWithInvalidId, res)
+      SubjectIdController.saveSubjectId(baseReq, res)
       expect(res.render).toBeCalledWith(
         'pages/subjectid',
         expect.objectContaining({

--- a/server/controllers/subjectIdController.ts
+++ b/server/controllers/subjectIdController.ts
@@ -6,7 +6,7 @@ export default class SubjectIdController {
     if (req.session.userData === undefined) {
       req.session.userData = {}
     }
-    const subjectId = req.session.userData.nomisId ? req.session.userData.nomisId : req.session.userData.ndeliusId
+    const { subjectId } = req.session.userData
 
     res.render('pages/subjectid', {
       subjectId,
@@ -15,23 +15,16 @@ export default class SubjectIdController {
 
   static saveSubjectId(req: Request, res: Response): void {
     const { subjectId } = req.body
-    const validatedSubjectId = SubjectIdValidation.validateSubjectId(subjectId)
+    const subjectIdError = SubjectIdValidation.validateSubjectId(subjectId)
 
-    if (validatedSubjectId === 'nomisId') {
-      req.session.userData.nomisId = subjectId
-      req.session.userData.ndeliusId = null
+    if (subjectIdError) {
+      res.render('pages/subjectid', {
+        subjectId,
+        subjectIdError,
+      })
+    } else {
+      req.session.userData.subjectId = subjectId
       res.redirect('/inputs')
-      return
     }
-    if (validatedSubjectId === 'ndeliusId') {
-      req.session.userData.ndeliusId = subjectId
-      req.session.userData.nomisId = null
-      res.redirect('/inputs')
-      return
-    }
-    res.render('pages/subjectid', {
-      subjectId,
-      subjectIdError: validatedSubjectId,
-    })
   }
 }

--- a/server/controllers/subjectIdController.ts
+++ b/server/controllers/subjectIdController.ts
@@ -1,20 +1,37 @@
 import type { Request, Response } from 'express'
+import SubjectIdValidation from './subjectIdValidation'
 
 export default class SubjectIdController {
   static getSubjectId(req: Request, res: Response) {
     if (req.session.userData === undefined) {
       req.session.userData = {}
     }
-    const { userData } = req.session
+    const subjectId = req.session.userData.nomisId ? req.session.userData.nomisId : req.session.userData.ndeliusId
+
     res.render('pages/subjectid', {
-      subjectId: userData.subjectId,
+      subjectId,
     })
   }
 
   static saveSubjectId(req: Request, res: Response): void {
     const { subjectId } = req.body
-    req.session.userData.subjectId = subjectId
+    const validatedSubjectId = SubjectIdValidation.validateSubjectId(subjectId)
 
-    res.redirect('/inputs')
+    if (validatedSubjectId === 'nomisId') {
+      req.session.userData.nomisId = subjectId
+      req.session.userData.ndeliusId = null
+      res.redirect('/inputs')
+      return
+    }
+    if (validatedSubjectId === 'ndeliusId') {
+      req.session.userData.ndeliusId = subjectId
+      req.session.userData.nomisId = null
+      res.redirect('/inputs')
+      return
+    }
+    res.render('pages/subjectid', {
+      subjectId,
+      subjectIdError: validatedSubjectId,
+    })
   }
 }

--- a/server/controllers/subjectIdValidation.test.ts
+++ b/server/controllers/subjectIdValidation.test.ts
@@ -5,7 +5,6 @@ describe('validateSubjectId', () => {
     missing: 'Enter subject ID',
     invalid: 'Subject ID must be a NOMIS prisoner number or nDelius case reference number',
   }
-  const accepted = ''
 
   test('validates that a subject ID is provided', () => {
     const subjectIdNotProvided = ''
@@ -17,14 +16,14 @@ describe('validateSubjectId', () => {
     test('accepts subject IDs in valid NOMIS ID format', () => {
       const validNomisIds = ['A1234BC', 'a1234bc', 'z9876YX', ' A1234BC', 'A1234BC ']
       validNomisIds.forEach(validNomisId => {
-        expect(SubjectIdValidation.validateSubjectId(validNomisId)).toEqual(accepted)
+        expect(SubjectIdValidation.validateSubjectId(validNomisId)).toEqual('nomisId')
       })
     })
 
     test('accepts subject IDs in valid nDelius ID format', () => {
       const validNdeliusIds = ['A123456', 'a123456', ' Z098765', 'Z098765 ']
       validNdeliusIds.forEach(validNdelousId => {
-        expect(SubjectIdValidation.validateSubjectId(validNdelousId)).toEqual(accepted)
+        expect(SubjectIdValidation.validateSubjectId(validNdelousId)).toEqual('ndeliusId')
       })
     })
 

--- a/server/controllers/subjectIdValidation.test.ts
+++ b/server/controllers/subjectIdValidation.test.ts
@@ -1,0 +1,13 @@
+import SubjectIdValidation from './subjectIdValidation'
+
+describe('validateSubjectId', () => {
+  const missing = 'Enter subject ID'
+
+  test('validates that a subject ID is provided', () => {
+    const subjectIdProvided = 'ExampleSubjectId'
+    const subjectIdNotProvided = ''
+
+    expect(SubjectIdValidation.validateSubjectId(subjectIdProvided)).toEqual('')
+    expect(SubjectIdValidation.validateSubjectId(subjectIdNotProvided)).toEqual(missing)
+  })
+})

--- a/server/controllers/subjectIdValidation.test.ts
+++ b/server/controllers/subjectIdValidation.test.ts
@@ -16,14 +16,14 @@ describe('validateSubjectId', () => {
     test('accepts subject IDs in valid NOMIS ID format', () => {
       const validNomisIds = ['A1234BC', 'a1234bc', 'z9876YX', ' A1234BC', 'A1234BC ']
       validNomisIds.forEach(validNomisId => {
-        expect(SubjectIdValidation.validateSubjectId(validNomisId)).toEqual('nomisId')
+        expect(SubjectIdValidation.validateSubjectId(validNomisId)).toBeNull()
       })
     })
 
     test('accepts subject IDs in valid nDelius ID format', () => {
       const validNdeliusIds = ['A123456', 'a123456', ' Z098765', 'Z098765 ']
       validNdeliusIds.forEach(validNdelousId => {
-        expect(SubjectIdValidation.validateSubjectId(validNdelousId)).toEqual('ndeliusId')
+        expect(SubjectIdValidation.validateSubjectId(validNdelousId)).toBeNull()
       })
     })
 

--- a/server/controllers/subjectIdValidation.test.ts
+++ b/server/controllers/subjectIdValidation.test.ts
@@ -3,8 +3,9 @@ import SubjectIdValidation from './subjectIdValidation'
 describe('validateSubjectId', () => {
   const errors = {
     missing: 'Enter subject ID',
-    valid: 'Subject ID must be a NOMIS prisoner number or nDelius case reference number',
+    invalid: 'Subject ID must be a NOMIS prisoner number or nDelius case reference number',
   }
+  const accepted = ''
 
   test('validates that a subject ID is provided', () => {
     const subjectIdNotProvided = ''
@@ -12,13 +13,26 @@ describe('validateSubjectId', () => {
     expect(SubjectIdValidation.validateSubjectId(subjectIdNotProvided)).toEqual(errors.missing)
   })
 
-  test('validates that the subject ID is in a valid format for a NOMIS or nDelius ID', () => {
-    const exampleNomisId = 'A1234BC'
-    const exampleNdeliusId = 'A123456'
-    const invalidSubjectId = 'A1A'
+  describe('when a subject ID is provided', () => {
+    test('accepts subject IDs in valid NOMIS ID format', () => {
+      const validNomisIds = ['A1234BC', 'a1234bc', 'z9876YX', ' A1234BC', 'A1234BC ']
+      validNomisIds.forEach(validNomisId => {
+        expect(SubjectIdValidation.validateSubjectId(validNomisId)).toEqual(accepted)
+      })
+    })
 
-    expect(SubjectIdValidation.validateSubjectId(exampleNomisId)).toEqual('')
-    expect(SubjectIdValidation.validateSubjectId(exampleNdeliusId)).toEqual('')
-    expect(SubjectIdValidation.validateSubjectId(invalidSubjectId)).toEqual(errors.valid)
+    test('accepts subject IDs in valid nDelius ID format', () => {
+      const validNdeliusIds = ['A123456', 'a123456', ' Z098765', 'Z098765 ']
+      validNdeliusIds.forEach(validNdelousId => {
+        expect(SubjectIdValidation.validateSubjectId(validNdelousId)).toEqual(accepted)
+      })
+    })
+
+    test('rejects subject IDs in neither valid NOMIS or nDelius format', () => {
+      const invalidIds = ['A1234B', 'a1234bcd', 'z987a6Y', 'A123 4BC', '-A12345']
+      invalidIds.forEach(invalidId => {
+        expect(SubjectIdValidation.validateSubjectId(invalidId)).toEqual(errors.invalid)
+      })
+    })
   })
 })

--- a/server/controllers/subjectIdValidation.test.ts
+++ b/server/controllers/subjectIdValidation.test.ts
@@ -1,13 +1,24 @@
 import SubjectIdValidation from './subjectIdValidation'
 
 describe('validateSubjectId', () => {
-  const missing = 'Enter subject ID'
+  const errors = {
+    missing: 'Enter subject ID',
+    valid: 'Subject ID must be a NOMIS prisoner number or nDelius case reference number',
+  }
 
   test('validates that a subject ID is provided', () => {
-    const subjectIdProvided = 'ExampleSubjectId'
     const subjectIdNotProvided = ''
 
-    expect(SubjectIdValidation.validateSubjectId(subjectIdProvided)).toEqual('')
-    expect(SubjectIdValidation.validateSubjectId(subjectIdNotProvided)).toEqual(missing)
+    expect(SubjectIdValidation.validateSubjectId(subjectIdNotProvided)).toEqual(errors.missing)
+  })
+
+  test('validates that the subject ID is in a valid format for a NOMIS or nDelius ID', () => {
+    const exampleNomisId = 'A1234BC'
+    const exampleNdeliusId = 'A123456'
+    const invalidSubjectId = 'A1A'
+
+    expect(SubjectIdValidation.validateSubjectId(exampleNomisId)).toEqual('')
+    expect(SubjectIdValidation.validateSubjectId(exampleNdeliusId)).toEqual('')
+    expect(SubjectIdValidation.validateSubjectId(invalidSubjectId)).toEqual(errors.valid)
   })
 })

--- a/server/controllers/subjectIdValidation.ts
+++ b/server/controllers/subjectIdValidation.ts
@@ -7,6 +7,10 @@ export default class SubjectIdValidation {
       if (!subjectId) {
         throw new ValidationError('Enter subject ID')
       }
+      // validate that format matches Nomis or nDelius ID format
+      if (!/^[A-Za-z][0-9]{4}[A-Za-z]{2}$/.exec(subjectId) && !/^[A-Za-z][0-9]{6}$/.exec(subjectId)) {
+        throw new ValidationError('Subject ID must be a NOMIS prisoner number or nDelius case reference number')
+      }
     } catch (e) {
       return e.message
     }

--- a/server/controllers/subjectIdValidation.ts
+++ b/server/controllers/subjectIdValidation.ts
@@ -1,0 +1,15 @@
+import ValidationError from '../utils/validationError'
+
+export default class SubjectIdValidation {
+  static validateSubjectId(subjectId: string): string {
+    try {
+      // mandatory field - if blank, error
+      if (!subjectId) {
+        throw new ValidationError('Enter subject ID')
+      }
+    } catch (e) {
+      return e.message
+    }
+    return ''
+  }
+}

--- a/server/controllers/subjectIdValidation.ts
+++ b/server/controllers/subjectIdValidation.ts
@@ -8,7 +8,7 @@ export default class SubjectIdValidation {
         throw new ValidationError('Enter subject ID')
       }
       // validate that format matches Nomis or nDelius ID format
-      if (!/^[A-Za-z][0-9]{4}[A-Za-z]{2}$/.exec(subjectId) && !/^[A-Za-z][0-9]{6}$/.exec(subjectId)) {
+      if (!/^[A-Za-z][0-9]{4}[A-Za-z]{2}$/.exec(subjectId.trim()) && !/^[A-Za-z][0-9]{6}$/.exec(subjectId.trim())) {
         throw new ValidationError('Subject ID must be a NOMIS prisoner number or nDelius case reference number')
       }
     } catch (e) {

--- a/server/controllers/subjectIdValidation.ts
+++ b/server/controllers/subjectIdValidation.ts
@@ -1,20 +1,16 @@
 import ValidationError from '../utils/validationError'
+import { isNdeliusId, isNomisId } from '../utils/idHelpers'
 
 export default class SubjectIdValidation {
   static validateSubjectId(subjectId: string): string {
-    const nomisId = /^[A-Za-z][0-9]{4}[A-Za-z]{2}$/
-    const ndeliusId = /^[A-Za-z][0-9]{6}$/
-
     try {
       // mandatory field - if blank, error
       if (!subjectId) {
         throw new ValidationError('Enter subject ID')
       }
       // validate that format matches Nomis or nDelius ID format
-      else if (nomisId.exec(subjectId.trim())) {
-        return 'nomisId'
-      } else if (ndeliusId.exec(subjectId.trim())) {
-        return 'ndeliusId'
+      else if (isNomisId(subjectId) || isNdeliusId(subjectId)) {
+        return null
       } else {
         throw new ValidationError('Subject ID must be a NOMIS prisoner number or nDelius case reference number')
       }

--- a/server/controllers/subjectIdValidation.ts
+++ b/server/controllers/subjectIdValidation.ts
@@ -2,18 +2,24 @@ import ValidationError from '../utils/validationError'
 
 export default class SubjectIdValidation {
   static validateSubjectId(subjectId: string): string {
+    const nomisId = /^[A-Za-z][0-9]{4}[A-Za-z]{2}$/
+    const ndeliusId = /^[A-Za-z][0-9]{6}$/
+
     try {
       // mandatory field - if blank, error
       if (!subjectId) {
         throw new ValidationError('Enter subject ID')
       }
       // validate that format matches Nomis or nDelius ID format
-      if (!/^[A-Za-z][0-9]{4}[A-Za-z]{2}$/.exec(subjectId.trim()) && !/^[A-Za-z][0-9]{6}$/.exec(subjectId.trim())) {
+      else if (nomisId.exec(subjectId.trim())) {
+        return 'nomisId'
+      } else if (ndeliusId.exec(subjectId.trim())) {
+        return 'ndeliusId'
+      } else {
         throw new ValidationError('Subject ID must be a NOMIS prisoner number or nDelius case reference number')
       }
     } catch (e) {
       return e.message
     }
-    return ''
   }
 }

--- a/server/utils/idHelpers.test.ts
+++ b/server/utils/idHelpers.test.ts
@@ -1,0 +1,35 @@
+import { isNomisId, isNdeliusId } from './idHelpers'
+
+describe('idHelpers', () => {
+  describe('isNomisId', () => {
+    test('returns true if given an ID in a valid NOMIS ID format', () => {
+      const validNomisIds = ['A1234BC', 'a1234bc', 'z9876YX', ' A1234BC', 'A1234BC ']
+      validNomisIds.forEach(validNomisId => {
+        expect(isNomisId(validNomisId)).toEqual(true)
+      })
+    })
+
+    test('returns false if given an ID that is not in a valid NOMIS ID format', () => {
+      const invalidIds = ['A123456', 'A1234B', 'a1234bcd', 'z987a6Y', 'A123 4BC', '-A12345']
+      invalidIds.forEach(invalidId => {
+        expect(isNomisId(invalidId)).toEqual(false)
+      })
+    })
+  })
+
+  describe('isNdeliusId', () => {
+    test('returns true if given an ID in a valid nDelius ID format', () => {
+      const validNdeliusIds = ['A123456', 'a123456', ' Z098765', 'Z098765 ']
+      validNdeliusIds.forEach(validNdeliusId => {
+        expect(isNdeliusId(validNdeliusId)).toEqual(true)
+      })
+    })
+
+    test('returns false if given an ID that is not in a valid NOMIS ID format', () => {
+      const invalidIds = ['A1234BC', 'A1234B', 'a1234bcd', 'z987a6Y', 'A123 4BC', '-A12345']
+      invalidIds.forEach(invalidId => {
+        expect(isNdeliusId(invalidId)).toEqual(false)
+      })
+    })
+  })
+})

--- a/server/utils/idHelpers.ts
+++ b/server/utils/idHelpers.ts
@@ -1,0 +1,5 @@
+const nomisIdRegex = /^[A-Za-z][0-9]{4}[A-Za-z]{2}$/
+const ndeliusIdRegex = /^[A-Za-z][0-9]{6}$/
+
+export const isNomisId = (id: string) => nomisIdRegex.test(id.trim())
+export const isNdeliusId = (id: string) => ndeliusIdRegex.test(id.trim())

--- a/server/views/pages/subjectid.njk
+++ b/server/views/pages/subjectid.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 
 {% block content %}
@@ -9,6 +10,24 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+
+      {% if subjectIdError %}
+        {% set showErrors = true %}
+        {% set subjectIdErrorMessage = {text: subjectIdError} %}
+      {% endif %}
+
+      {% if showErrors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [
+            {
+              text: subjectIdError,
+              href: "#subject-id"
+            }
+          ]
+        }) }}
+      {% endif %}
+
       <form action="/subject-id" method="post">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {{ govukInput({
@@ -23,7 +42,8 @@
             value: subjectId,
             hint: {
               text: "Provide a NOMIS Prisoner Number or a nDelius Case Reference Number for the subject of the Subject Access Request."
-            }
+            },
+            errorMessage: subjectIdErrorMessage
           }) }}
 
         <div class="govuk-inset-text" id="additional-information">


### PR DESCRIPTION
## Context

In #20, we created a subject ID page where the user is asked to supply either a NOMIS prisoner ID or an nDelius probation ID for the subject of the Subject Access Request.

## Changes proposed in this pull request

* Adds [validation for the subject ID](https://dsdmoj.atlassian.net/browse/SR-115), specifically:
  * that the input field has not been left blank
  * that the format of the subject ID provided matches the NOMIS or nDelius ID convention

https://github.com/ministryofjustice/hmpps-subject-access-request-ui/assets/95350189/24c07074-e9f3-4043-b334-002de70c9938


## Next steps

* Swap the regexes used to check the format out with those provided by our stakeholders if it differs from those used.