### PR TITLE
Create view reports page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ parameters:
     type: string
     # Normally team specific alert channel e.g. hmpps_tech_alerts, syscon-alerts, dps_sed_alerts
     # This is to avoid a general alert dumping ground that no-one then monitors
-    default: hmpps_typescript_notifications
+    default: subject-access-request-alerts-dev
 
   releases-slack-channel:
     type: string
     # Normally dps-releases for most teams / projects
-    default: hmpps_typescript_notifications
+    default: subject-access-request-alerts-dev
 
   node-version:
     type: string

--- a/helm_deploy/hmpps-subject-access-request-ui/values.yaml
+++ b/helm_deploy/hmpps-subject-access-request-ui/values.yaml
@@ -62,6 +62,7 @@ generic-service:
     cloudplatform-live-1: "35.178.209.113/32"
     cloudplatform-live-2: "3.8.51.207/32"
     cloudplatform-live-3: "35.177.252.54/32"
+    all: "0.0.0.0/0"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-subject-access-request-ui

--- a/integration_tests/e2e/confirmation.cy.ts
+++ b/integration_tests/e2e/confirmation.cy.ts
@@ -33,11 +33,11 @@ context('Confirmation', () => {
     confirmationPage.nextSteps().should('exist')
   })
 
-  it('Displays link to view reports page', () => {
+  it('Redirects to /reports on clicking view reports link', () => {
     cy.signIn()
     cy.visit('/confirmation')
     const confirmationPage = Page.verifyOnPage(ConfirmationPage)
-    confirmationPage.viewReportsLink().should('exist')
-    confirmationPage.viewReportsLink().should('have.attr', 'href', '/reports')
+    confirmationPage.viewReportsLink().click()
+    cy.url().should('to.match', /reports$/)
   })
 })

--- a/integration_tests/e2e/reports.cy.ts
+++ b/integration_tests/e2e/reports.cy.ts
@@ -29,4 +29,13 @@ context('Reports', () => {
     reportsPage.reportsTable().contains('Subject ID')
     reportsPage.reportsTable().contains('Status')
   })
+
+  it('Can be sorted on date of request', () => {
+    cy.signIn()
+    cy.visit('/reports')
+    const reportsPage = Page.verifyOnPage(ReportsPage)
+    reportsPage.reportsTableRow().first().contains('2024-12-01')
+    reportsPage.sortByDateButton().click()
+    reportsPage.reportsTableRow().first().contains('2022-12-30')
+  })
 })

--- a/integration_tests/e2e/reports.cy.ts
+++ b/integration_tests/e2e/reports.cy.ts
@@ -1,0 +1,20 @@
+import Page from '../pages/page'
+import AuthSignInPage from '../pages/authSignIn'
+
+context('Reports', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubManageUser')
+  })
+
+  it('Redirects to auth if requested by unauthenticated user', () => {
+    cy.visit('/reports')
+    Page.verifyOnPage(AuthSignInPage)
+  })
+
+  it('Renders for authenticated users', () => {
+    cy.signIn()
+    cy.visit('/reports')
+  })
+})

--- a/integration_tests/e2e/reports.cy.ts
+++ b/integration_tests/e2e/reports.cy.ts
@@ -1,5 +1,6 @@
 import Page from '../pages/page'
 import AuthSignInPage from '../pages/authSignIn'
+import ReportsPage from '../pages/reports'
 
 context('Reports', () => {
   beforeEach(() => {
@@ -16,5 +17,16 @@ context('Reports', () => {
   it('Renders for authenticated users', () => {
     cy.signIn()
     cy.visit('/reports')
+  })
+
+  it('Displays table of reports', () => {
+    cy.signIn()
+    cy.visit('/reports')
+    const reportsPage = Page.verifyOnPage(ReportsPage)
+    reportsPage.reportsTable().should('exist')
+    reportsPage.reportsTable().contains('Date of request')
+    reportsPage.reportsTable().contains('Case Reference')
+    reportsPage.reportsTable().contains('Subject ID')
+    reportsPage.reportsTable().contains('Status')
   })
 })

--- a/integration_tests/pages/reports.ts
+++ b/integration_tests/pages/reports.ts
@@ -1,0 +1,9 @@
+import Page, { PageElement } from './page'
+
+export default class SubjectIdPage extends Page {
+  constructor() {
+    super('Subject Access Request Reports')
+  }
+
+  reportsTable = (): PageElement => cy.get('.govuk-table')
+}

--- a/integration_tests/pages/reports.ts
+++ b/integration_tests/pages/reports.ts
@@ -6,4 +6,8 @@ export default class SubjectIdPage extends Page {
   }
 
   reportsTable = (): PageElement => cy.get('.govuk-table')
+
+  sortByDateButton = (): PageElement => cy.get('button:contains("Date of request")')
+
+  reportsTableRow = (): PageElement => cy.get('.govuk-table__body').find('.govuk-table__row')
 }

--- a/server/@types/report.d.ts
+++ b/server/@types/report.d.ts
@@ -1,0 +1,7 @@
+export interface Report {
+  uuid: string
+  dateOfRequest: string
+  sarCaseReference: string
+  subjectId: string
+  status: string
+}

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -1,0 +1,74 @@
+import type { Request, Response } from 'express'
+import ReportsController from './reportsController'
+
+beforeEach(() => {
+  ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue([
+    {
+      uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+      dateOfRequest: '2024-12-20',
+      sarCaseReference: 'example1',
+      subjectId: 'B1234AA',
+      status: 'Pending',
+    },
+    {
+      uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+      dateOfRequest: '2023-01-19',
+      sarCaseReference: 'example2',
+      subjectId: 'C2345BB',
+      status: 'Complete',
+    },
+    {
+      uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+      dateOfRequest: '2022-16-18',
+      sarCaseReference: 'example3',
+      subjectId: 'D3456CC',
+      status: 'Complete',
+    },
+  ])
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('getReports', () => {
+  const req: Request = {
+    // @ts-expect-error stubbing session
+    session: {},
+  }
+  // @ts-expect-error stubbing res.render
+  const res: Response = {
+    render: jest.fn(),
+  }
+  test('renders a response with list of SAR reports', () => {
+    ReportsController.getReports(req, res)
+    expect(res.render).toBeCalledWith(
+      'pages/reports',
+      expect.objectContaining({
+        reportList: [
+          {
+            dateOfRequest: '2024-12-20',
+            sarCaseReference: 'example1',
+            status: 'Pending',
+            subjectId: 'B1234AA',
+            uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+          },
+          {
+            dateOfRequest: '2023-01-19',
+            sarCaseReference: 'example2',
+            status: 'Complete',
+            subjectId: 'C2345BB',
+            uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+          },
+          {
+            dateOfRequest: '2022-16-18',
+            sarCaseReference: 'example3',
+            status: 'Complete',
+            subjectId: 'D3456CC',
+            uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+          },
+        ],
+      }),
+    )
+  })
+})

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -1,5 +1,4 @@
 import type { Request, Response } from 'express'
-import { Report } from '../@types/report'
 
 export default class ReportsController {
   static getSubjectAccessRequestList() {

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -1,0 +1,39 @@
+import type { Request, Response } from 'express'
+import { Report } from '../@types/report'
+
+export default class ReportsController {
+  static getSubjectAccessRequestList() {
+    const reports = [
+      {
+        uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+        dateOfRequest: '2024-12-01',
+        sarCaseReference: '1-casereference',
+        subjectId: 'A1234AA',
+        status: 'Pending',
+      },
+      {
+        uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+        dateOfRequest: '2023-07-30',
+        sarCaseReference: '2-casereference',
+        subjectId: 'B2345BB',
+        status: 'Complete',
+      },
+      {
+        uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+        dateOfRequest: '2022-12-30',
+        sarCaseReference: '3-casereference',
+        subjectId: 'C3456CC',
+        status: 'Complete',
+      },
+    ]
+    return reports
+  }
+
+  static getReports(req: Request, res: Response) {
+    const reports = ReportsController.getSubjectAccessRequestList()
+
+    res.render('pages/reports', {
+      reportList: reports,
+    })
+  }
+}

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -102,3 +102,14 @@ describe('GET /confirmation', () => {
       })
   })
 })
+
+describe('GET /reports', () => {
+  it('should render reports page', () => {
+    return request(app)
+      .get('/reports')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Subject Access Request Reports')
+      })
+  })
+})

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,7 @@ import ServiceSelectionController from '../controllers/serviceSelectionControlle
 import SummaryController from '../controllers/summaryController'
 import ConfirmationController from '../controllers/confirmationController'
 import SubjectIdController from '../controllers/subjectIdController'
+import ReportsController from '../controllers/reportsController'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(service: Services): Router {
@@ -32,9 +33,7 @@ export default function routes(service: Services): Router {
 
   get('/confirmation', ConfirmationController.getConfirmation)
 
-  get('/reports', (req, res, next) => {
-    res.render('pages/reports')
-  })
+  get('/reports', ReportsController.getReports)
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -32,5 +32,9 @@ export default function routes(service: Services): Router {
 
   get('/confirmation', ConfirmationController.getConfirmation)
 
+  get('/reports', (req, res, next) => {
+    res.render('pages/reports')
+  })
+
   return router
 }

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -12,10 +12,9 @@
 
     <section id="next-steps">
       <h2 class="govuk-heading-m">What happens next</h2>
-      <p class="govuk-body">Lorem ipsum sit dolor et amet - content to be confirmed.</p>
-      <p class="govuk-body">You will not get an email notification about this report. But you can check its progress on the completed reports page.</p>
+      <p class="govuk-body">You can check on the progress of this report and view it after completion on the <a href="/reports">completed reports</a> page.</p>
+      <p class="govuk-body">You will not get an email notification about this report.</p>
     </section>
-
     <a href="/reports" class="govuk-body govuk-link" id="view-reports">View completed reports.</a>
 
   {% endblock %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -4,7 +4,8 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-  <h1><a href="./subject-id">PLACEHOLDER: Start report</a></h1>
+  <h1><a href="./subject-id">PLACEHOLDER: Request a Report</a></h1>
+  <h1><a href="./reports">PLACEHOLDER: View Reports</a></h1>
   <h1>This site is under construction...</h1>
   <p>Please check back later when there is content to view.</p>
 

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -6,7 +6,6 @@
   <h1 class="govuk-heading-l">Subject Access Request Reports</h1>
 
     <table class="govuk-table" data-module="moj-sortable-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Dates and amounts</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header" aria-sort="descending">Date of request</th>

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -5,11 +5,11 @@
 
   <h1 class="govuk-heading-l">Subject Access Request Reports</h1>
 
-    <table class="govuk-table">
+    <table class="govuk-table" data-module="moj-sortable-table">
       <caption class="govuk-table__caption govuk-table__caption--m">Dates and amounts</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Date of request</th>
+          <th scope="col" class="govuk-table__header" aria-sort="descending">Date of request</th>
           <th scope="col" class="govuk-table__header">Case Reference</th>
           <th scope="col" class="govuk-table__header">Subject ID</th>
           <th scope="col" class="govuk-table__header">Status</th>

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -5,66 +5,26 @@
 
   <h1 class="govuk-heading-l">Subject Access Request Reports</h1>
 
-  {{ govukTable({
-    firstCellIsHeader: false,
-    head: [
-      {
-        text: "Date of request"
-      },
-      {
-        text: "Case Reference"
-      },
-      {
-        text: "Subject ID"
-      },
-      {
-        text: "Status"
-      }
-    ],
-    rows: [
-      [
-        {
-          text: "25/03/2024"
-        },
-        {
-          text: "CaseReference1"
-        },
-        {
-          text: "A1234BC"
-        },
-        {
-          text: "Pending"
-        }
-      ],
-      [
-        {
-          text: "24/02/2024"
-        },
-        {
-          text: "CaseReference2"
-        },
-        {
-          text: "B1234CD"
-        },
-        {
-          text: "Complete"
-        }
-      ],
-      [
-        {
-          text: "23/01/2024"
-        },
-        {
-          text: "CaseReference3"
-        },
-        {
-          text: "C123456"
-        },
-        {
-          text: "Complete"
-        }
-      ]
-    ]
-  }) }}
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Dates and amounts</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Date of request</th>
+          <th scope="col" class="govuk-table__header">Case Reference</th>
+          <th scope="col" class="govuk-table__header">Subject ID</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for report in reportList %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{report.dateOfRequest}}</td>
+                    <td class="govuk-table__cell">{{report.sarCaseReference}}</td>
+                    <td class="govuk-table__cell">{{report.subjectId}}</td>
+                    <td class="govuk-table__cell">{{report.status}}</td>
+                </tr>
+            {% endfor %}
+      </tbody>
+    </table>
 
 {% endblock %}

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -1,6 +1,70 @@
 {% extends "../partials/layout.njk" %}
-
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% block content %}
+
   <h1 class="govuk-heading-l">Subject Access Request Reports</h1>
+
+  {{ govukTable({
+    firstCellIsHeader: false,
+    head: [
+      {
+        text: "Date of request"
+      },
+      {
+        text: "Case Reference"
+      },
+      {
+        text: "Subject ID"
+      },
+      {
+        text: "Status"
+      }
+    ],
+    rows: [
+      [
+        {
+          text: "25/03/2024"
+        },
+        {
+          text: "CaseReference1"
+        },
+        {
+          text: "A1234BC"
+        },
+        {
+          text: "Pending"
+        }
+      ],
+      [
+        {
+          text: "24/02/2024"
+        },
+        {
+          text: "CaseReference2"
+        },
+        {
+          text: "B1234CD"
+        },
+        {
+          text: "Complete"
+        }
+      ],
+      [
+        {
+          text: "23/01/2024"
+        },
+        {
+          text: "CaseReference3"
+        },
+        {
+          text: "C123456"
+        },
+        {
+          text: "Complete"
+        }
+      ]
+    ]
+  }) }}
+
 {% endblock %}

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -1,0 +1,6 @@
+{% extends "../partials/layout.njk" %}
+
+
+{% block content %}
+  <h1 class="govuk-heading-l">Subject Access Request Reports</h1>
+{% endblock %}


### PR DESCRIPTION
## Changes proposed in this pull request

This PR [adds a reports page](https://dsdmoj.atlassian.net/browse/SR-97) that is accessible from the homepage and via the confirmation screen following submission of. a new report request.

![image](https://github.com/ministryofjustice/hmpps-subject-access-request-ui/assets/95350189/2ad8fe6f-67f3-487c-ad80-8d0457cd21fd)

## Next steps
* Paginate the table data
* Build and integrate with the API endpoint to retrieve paginated report list data from the SAR database.