### PR TITLE
Add pagination to reports table

### DIFF
--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -2,29 +2,32 @@ import type { Request, Response } from 'express'
 import ReportsController from './reportsController'
 
 beforeEach(() => {
-  ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue([
-    {
-      uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
-      dateOfRequest: '2024-12-20',
-      sarCaseReference: 'example1',
-      subjectId: 'B1234AA',
-      status: 'Pending',
-    },
-    {
-      uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
-      dateOfRequest: '2023-01-19',
-      sarCaseReference: 'example2',
-      subjectId: 'C2345BB',
-      status: 'Complete',
-    },
-    {
-      uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
-      dateOfRequest: '2022-16-18',
-      sarCaseReference: 'example3',
-      subjectId: 'D3456CC',
-      status: 'Complete',
-    },
-  ])
+  ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue({
+    reports: [
+      {
+        uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+        dateOfRequest: '2024-12-20',
+        sarCaseReference: 'example1',
+        subjectId: 'B1234AA',
+        status: 'Pending',
+      },
+      {
+        uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+        dateOfRequest: '2023-01-19',
+        sarCaseReference: 'example2',
+        subjectId: 'C2345BB',
+        status: 'Complete',
+      },
+      {
+        uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+        dateOfRequest: '2022-16-18',
+        sarCaseReference: 'example3',
+        subjectId: 'D3456CC',
+        status: 'Complete',
+      },
+    ],
+    numberOfReports: 3,
+  })
 })
 
 afterEach(() => {

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -84,13 +84,12 @@ describe('getReports', () => {
       })
     })
     describe('when the current page is the first page', () => {
-      test('previous remains on first page', () => {
-        // TODO: update to remove previous for first page
+      test('previous will be 0 and so will not appear', () => {
         ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
-            previous: 1,
+            previous: 0,
           }),
         )
       })
@@ -154,13 +153,12 @@ describe('getReports', () => {
         )
       })
 
-      test('next remains on the fifth page', () => {
-        // TODO: remove the next button on last pages
+      test('next will be 0 and so will not appear', () => {
         ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
-            next: 5,
+            next: 0,
           }),
         )
       })

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -35,9 +35,10 @@ afterEach(() => {
 })
 
 describe('getReports', () => {
-  const req: Request = {
+  let req: Request = {
     // @ts-expect-error stubbing session
     session: {},
+    query: {},
   }
   // @ts-expect-error stubbing res.render
   const res: Response = {
@@ -73,5 +74,185 @@ describe('getReports', () => {
         ],
       }),
     )
+  })
+
+  describe('pagination', () => {
+    beforeEach(() => {
+      ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue({
+        reports: [],
+        numberOfReports: 240,
+      })
+    })
+    describe('when the current page is the first page', () => {
+      test('previous remains on first page', () => {
+        // TODO: update to remove previous for first page
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            previous: 1,
+          }),
+        )
+      })
+
+      test('next directs to second page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            next: 2,
+          }),
+        )
+      })
+
+      test('from gives the first number of the range of displayed results on the page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            from: 1,
+          }),
+        )
+      })
+
+      test('to gives the last number of the range of displayed results on the page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            to: 50,
+          }),
+        )
+      })
+
+      test('numberOfReports gives the total number of reports', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            numberOfReports: 240,
+          }),
+        )
+      })
+    })
+
+    describe('when the current page is the fifth page', () => {
+      beforeEach(() => {
+        req = {
+          // @ts-expect-error stubbing session
+          session: {},
+          query: { page: '5' },
+        }
+      })
+      test('previous directs to the fourth page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            previous: 4,
+          }),
+        )
+      })
+
+      test('next remains on the fifth page', () => {
+        // TODO: remove the next button on last pages
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            next: 5,
+          }),
+        )
+      })
+
+      test('from gives the first number of the range of displayed results on the page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            from: 201,
+          }),
+        )
+      })
+
+      test('to gives the last number of the range of displayed results on the page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            to: 240,
+          }),
+        )
+      })
+
+      test('numberOfReports gives the total number of reports', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            numberOfReports: 240,
+          }),
+        )
+      })
+    })
+
+    describe('when the current page is the third page', () => {
+      beforeEach(() => {
+        req = {
+          // @ts-expect-error stubbing session
+          session: {},
+          query: { page: '3' },
+        }
+      })
+      test('previous directs to the second page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            previous: 2,
+          }),
+        )
+      })
+
+      test('next directs to fourth page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            next: 4,
+          }),
+        )
+      })
+
+      test('from gives the first number of the range of displayed results on the page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            from: 101,
+          }),
+        )
+      })
+
+      test('to gives the last number of the range of displayed results on the page', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            to: 150,
+          }),
+        )
+      })
+
+      test('numberOfReports gives the total number of reports', () => {
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            numberOfReports: 240,
+          }),
+        )
+      })
+    })
   })
 })

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -1,7 +1,12 @@
 import type { Request, Response } from 'express'
+import getPageLinks from '../utils/paginationHelper'
+
+const RESULTSPERPAGE = 50
 
 export default class ReportsController {
   static getSubjectAccessRequestList() {
+    const numberOfReports = 500
+
     const reports = [
       {
         uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
@@ -25,14 +30,27 @@ export default class ReportsController {
         status: 'Complete',
       },
     ]
-    return reports
+    return { reports, numberOfReports }
   }
 
   static getReports(req: Request, res: Response) {
-    const reports = ReportsController.getSubjectAccessRequestList()
+    const { reports, numberOfReports } = ReportsController.getSubjectAccessRequestList()
+
+    const previous = 1
+    const next = 2
+    const from = 1
+    const to = 50
+
+    const pageLinks = getPageLinks({ pagesToShow: 5, numberOfPages: 50, currentPage: 1 })
 
     res.render('pages/reports', {
       reportList: reports,
+      pageLinks,
+      previous,
+      next,
+      from,
+      to,
+      numberOfReports,
     })
   }
 }

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -35,13 +35,17 @@ export default class ReportsController {
 
   static getReports(req: Request, res: Response) {
     const { reports, numberOfReports } = ReportsController.getSubjectAccessRequestList()
+    const currentPage = (req.query.page || '1') as string
+    const parsedPage = Number.parseInt(currentPage, 10) || 1
+    const visiblePageLinks = 5
+    const numberOfPages = Math.ceil(numberOfReports / RESULTSPERPAGE)
 
-    const previous = 1
-    const next = 2
-    const from = 1
-    const to = 50
+    const previous = Math.max(1, parsedPage - 1)
+    const next = Math.min(parsedPage + 1, numberOfPages)
+    const from = (parsedPage - 1) * RESULTSPERPAGE + 1
+    const to = Math.min(parsedPage * RESULTSPERPAGE, numberOfReports)
 
-    const pageLinks = getPageLinks({ pagesToShow: 5, numberOfPages: 50, currentPage: 1 })
+    const pageLinks = getPageLinks({ visiblePageLinks, numberOfPages, currentPage: parsedPage })
 
     res.render('pages/reports', {
       reportList: reports,

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -40,8 +40,9 @@ export default class ReportsController {
     const visiblePageLinks = 5
     const numberOfPages = Math.ceil(numberOfReports / RESULTSPERPAGE)
 
-    const previous = Math.max(1, parsedPage - 1)
-    const next = Math.min(parsedPage + 1, numberOfPages)
+    const previous = parsedPage - 1
+    const next = parsedPage === numberOfPages ? 0 : parsedPage + 1
+
     const from = (parsedPage - 1) * RESULTSPERPAGE + 1
     const to = Math.min(parsedPage * RESULTSPERPAGE, numberOfReports)
 

--- a/server/utils/paginationHelper.test.ts
+++ b/server/utils/paginationHelper.test.ts
@@ -1,0 +1,10 @@
+import getPageLinks from './paginationHelper'
+import paginationHelperTestData from './paginationHelper.testData'
+
+describe('Return pagination pages', () => {
+  paginationHelperTestData.forEach(testData => {
+    it(testData.description, () => {
+      expect(getPageLinks(testData.params)).toEqual(testData.result)
+    })
+  })
+})

--- a/server/utils/paginationHelper.testData.ts
+++ b/server/utils/paginationHelper.testData.ts
@@ -1,0 +1,70 @@
+const getSingleRow = (selected: boolean, page: number): { href: string; selected: boolean; text: string } => {
+  return {
+    href: `/reports?page=${page}`,
+    selected,
+    text: page.toString(),
+  }
+}
+
+export default [
+  {
+    description: 'Show 1 page, 1 page available, current page is 1',
+    params: { visiblePageLinks: 1, numberOfPages: 1, currentPage: 1 },
+    result: [getSingleRow(true, 1)],
+  },
+  {
+    description: 'Show 1 page, 2 pages available, current page is 1',
+    params: { visiblePageLinks: 1, numberOfPages: 2, currentPage: 1 },
+    result: [getSingleRow(true, 1)],
+  },
+  {
+    description: 'Show 1 page, 2 pages available, current page is 2',
+    params: { visiblePageLinks: 1, numberOfPages: 2, currentPage: 2 },
+    result: [getSingleRow(true, 2)],
+  },
+  {
+    description: 'Show 1 page, 3 pages available, current page is 1',
+    params: { visiblePageLinks: 1, numberOfPages: 3, currentPage: 1 },
+    result: [getSingleRow(true, 1)],
+  },
+  {
+    description: 'Show 1 page, 3 pages available, current page is 2',
+    params: { visiblePageLinks: 1, numberOfPages: 3, currentPage: 2 },
+    result: [getSingleRow(true, 2)],
+  },
+  {
+    description: 'Show 1 page, 3 pages available, current page is 3',
+    params: { visiblePageLinks: 1, numberOfPages: 3, currentPage: 3 },
+    result: [getSingleRow(true, 3)],
+  },
+  {
+    description: 'Show 2 pages, 1 page available, current page is 1',
+    params: { visiblePageLinks: 2, numberOfPages: 1, currentPage: 1 },
+    result: [getSingleRow(true, 1)],
+  },
+  {
+    description: 'Show 2 pages, 2 pages available, current page is 1',
+    params: { visiblePageLinks: 2, numberOfPages: 2, currentPage: 1 },
+    result: [getSingleRow(true, 1), getSingleRow(false, 2)],
+  },
+  {
+    description: 'Show 2 pages, 2 pages available, current page is 2',
+    params: { visiblePageLinks: 2, numberOfPages: 2, currentPage: 2 },
+    result: [getSingleRow(false, 1), getSingleRow(true, 2)],
+  },
+  {
+    description: 'Show 2 pages, 3 pages available, current page is 1',
+    params: { visiblePageLinks: 2, numberOfPages: 3, currentPage: 1 },
+    result: [getSingleRow(true, 1), getSingleRow(false, 2)],
+  },
+  {
+    description: 'Show 2 pages, 3 pages available, current page is 2',
+    params: { visiblePageLinks: 2, numberOfPages: 3, currentPage: 2 },
+    result: [getSingleRow(true, 2), getSingleRow(false, 3)],
+  },
+  {
+    description: 'Show 2 pages, 3 pages available, current page is 3',
+    params: { visiblePageLinks: 2, numberOfPages: 3, currentPage: 3 },
+    result: [getSingleRow(false, 2), getSingleRow(true, 3)],
+  },
+]

--- a/server/utils/paginationHelper.ts
+++ b/server/utils/paginationHelper.ts
@@ -1,0 +1,42 @@
+const getPageLinks = ({
+  visiblePageLinks = 1,
+  numberOfPages = 1,
+  currentPage = 1,
+}: {
+  visiblePageLinks: number
+  numberOfPages: number
+  currentPage: number
+}): Array<{ text: string; href: string; selected: boolean }> => {
+  let pageStartNumber = 1
+  let pageEndNumber = visiblePageLinks
+  const pageLinks = []
+
+  if (numberOfPages <= visiblePageLinks) {
+    pageEndNumber = numberOfPages
+  } else {
+    const endPageOffset = currentPage + (visiblePageLinks - 1)
+
+    if (endPageOffset === numberOfPages) {
+      pageStartNumber = endPageOffset - (visiblePageLinks - 1)
+      pageEndNumber = endPageOffset
+    } else if (endPageOffset > numberOfPages) {
+      pageStartNumber = numberOfPages - visiblePageLinks + 1
+      pageEndNumber = numberOfPages
+    } else {
+      pageStartNumber = currentPage
+      pageEndNumber = endPageOffset
+    }
+  }
+
+  for (let pageIndex = pageStartNumber; pageIndex <= pageEndNumber; pageIndex += 1) {
+    pageLinks.push({
+      text: pageIndex.toString(),
+      // TODO: Genericise pagination helper - pass in URL
+      href: `/reports?page=${pageIndex}`,
+      selected: pageIndex === currentPage,
+    })
+  }
+
+  return pageLinks
+}
+export default getPageLinks

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -1,9 +1,31 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 
 {% block content %}
 
+      {% set pagination %}
+        {{ mojPagination({
+          results: {
+            from: from,
+            to: to,
+            count: numberOfReports
+          },
+          previous: {
+            text: 'Previous',
+            href: '/reports?page=' + previous
+          },
+          next: {
+            text: 'Next',
+            href: '/reports?page=' + next
+          },
+          items: pageLinks
+        }) }}
+      {% endset %}
+
   <h1 class="govuk-heading-l">Subject Access Request Reports</h1>
+
+  {{ pagination | safe }}
 
     <table class="govuk-table" data-module="moj-sortable-table">
       <thead class="govuk-table__head">
@@ -25,5 +47,7 @@
             {% endfor %}
       </tbody>
     </table>
+
+  {{ pagination | safe }}
 
 {% endblock %}

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -4,6 +4,14 @@
 
 {% block content %}
 
+{% if previous != 0 %}
+  {% set previousButton = { text: 'Previous', href: '/reports?page=' + previous } %}
+{% endif %}
+
+{% if next != 0 %}
+  {% set nextButton = { text: 'Next', href: '/reports?page=' + next } %}
+{% endif %}
+
       {% set pagination %}
         {{ mojPagination({
           results: {
@@ -11,14 +19,8 @@
             to: to,
             count: numberOfReports
           },
-          previous: {
-            text: 'Previous',
-            href: '/reports?page=' + previous
-          },
-          next: {
-            text: 'Next',
-            href: '/reports?page=' + next
-          },
+          previous: previousButton,
+          next: nextButton,
           items: pageLinks
         }) }}
       {% endset %}


### PR DESCRIPTION
## Context

In #34 we added a View Reports page to allow users to view historically created reports. This formed the first half of [SR-97](https://dsdmoj.atlassian.net/browse/SR-97) to create a paginated View Reports page.

## Changes proposed in this pull request

This PR adds pagination to the reports table.

<img width="1103" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-ui/assets/95350189/b0ed6bc5-d6e8-4c97-8cfc-556591c439a1">


[SR-97]: https://dsdmoj.atlassian.net/browse/SR-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ