### PR TITLE
Add requestor ID to SAR

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -12,6 +12,7 @@ const createToken = () => {
     authorities: [],
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     client_id: 'clientid',
+    user_uuid: 'mockUUID',
   }
 
   return jwt.sign(payload, 'secret', { expiresIn: '1h' })

--- a/server/controllers/summaryController.test.ts
+++ b/server/controllers/summaryController.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock'
 import SummaryController from './summaryController'
 import config from '../config'
 
-SummaryController.getUserToken = jest.fn().mockReturnValue('testtoken')
+SummaryController.getSystemToken = jest.fn().mockReturnValue('testtoken')
 
 let fakeApi: nock.Scope
 
@@ -26,7 +26,6 @@ describe('getReportDetails', () => {
     const req: Request = {
       // @ts-expect-error stubbing session
       session: {
-        serviceList: [],
         userData: {
           subjectId: 'A1111AA',
           dateFrom: '01/01/2001',
@@ -35,7 +34,6 @@ describe('getReportDetails', () => {
         },
         selectedList: [{ id: '1', text: 'service1' }],
       },
-      body: { selectedservices: [] },
     }
     SummaryController.getReportDetails(req, res)
     expect(res.render).toHaveBeenCalled()
@@ -61,7 +59,6 @@ describe('postReportDetails', () => {
     const req: Request = {
       // @ts-expect-error stubbing session
       session: {
-        serviceList: [],
         userData: {
           dateFrom: '01/01/2001',
           dateTo: '25/12/2022',
@@ -70,13 +67,17 @@ describe('postReportDetails', () => {
         },
         selectedList: [{ id: '1', text: 'service1', urls: '.com' }],
       },
-      body: { selectedservices: [] },
+      user: {
+        token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3V1aWQiOiJtb2NrZWRVc2VySWQiLCJuYW1lIjoiRXhhbXBsZSBVc2VyIn0.KcjDfjwlAS8Jlz7swp-X2FlSyRAFtEKvQ6WuzLSzAaU',
+        authSource: 'auth',
+      },
     }
 
     fakeApi
       .post(
         '/api/createSubjectAccessRequest',
-        '{"dateFrom":"01/01/2001","dateTo":"25/12/2022","sarCaseReferenceNumber":"mockedCaseReference","services":"service1, .com","nomisId":"A1111AA","ndeliusId":""}',
+        '{"dateFrom":"01/01/2001","dateTo":"25/12/2022","sarCaseReferenceNumber":"mockedCaseReference","services":"service1, .com","nomisId":"A1111AA","ndeliusId":"","requestedBy":"mockedUserId"}',
       )
       .reply(200)
 
@@ -90,7 +91,6 @@ describe('postReportDetails', () => {
     const req: Request = {
       // @ts-expect-error stubbing session
       session: {
-        serviceList: [],
         userData: {
           dateFrom: '01/01/2001',
           dateTo: '25/12/2022',
@@ -99,12 +99,16 @@ describe('postReportDetails', () => {
         },
         selectedList: [{ id: '1', text: 'service1', urls: '.com' }],
       },
-      body: { selectedservices: [] },
+      user: {
+        token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3V1aWQiOiJtb2NrZWRVc2VySWQiLCJuYW1lIjoiRXhhbXBsZSBVc2VyIn0.KcjDfjwlAS8Jlz7swp-X2FlSyRAFtEKvQ6WuzLSzAaU',
+        authSource: 'auth',
+      },
     }
     nock(config.apis.subjectAccessRequest.url)
       .post(
         '/api/createSubjectAccessRequest',
-        '{"dateFrom":"01/01/2001","dateTo":"25/12/2022","sarCaseReferenceNumber":"mockedCaseReference","services":"service1, .com","nomisId":"","ndeliusId":""}',
+        '{"dateFrom":"01/01/2001","dateTo":"25/12/2022","sarCaseReferenceNumber":"mockedCaseReference","services":"service1, .com","nomisId":"","ndeliusId":"","requestedBy":"mockedUserId"}',
       )
       .reply(400)
     await expect(SummaryController.postReportDetails(req, res)).rejects.toThrowError('Bad Request')

--- a/server/controllers/summaryController.test.ts
+++ b/server/controllers/summaryController.test.ts
@@ -113,4 +113,27 @@ describe('postReportDetails', () => {
       .reply(400)
     await expect(SummaryController.postReportDetails(req, res)).rejects.toThrowError('Bad Request')
   })
+
+  test('post request fails if no user ID could be found', async () => {
+    const req: Request = {
+      // @ts-expect-error stubbing session
+      session: {
+        userData: {
+          dateFrom: '01/01/2001',
+          dateTo: '25/12/2022',
+          caseReference: 'mockedCaseReference',
+          subjectId: 'A123456',
+        },
+        selectedList: [{ id: '1', text: 'service1', urls: '.com' }],
+      },
+      user: {
+        token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        authSource: 'auth',
+      },
+    }
+    await expect(SummaryController.postReportDetails(req, res)).rejects.toThrowError(
+      'Could not identify SAR requestor. RequestedBy field is null.',
+    )
+  })
 })

--- a/server/controllers/summaryController.ts
+++ b/server/controllers/summaryController.ts
@@ -3,6 +3,7 @@ import superagent from 'superagent'
 import config from '../config'
 import { isNomisId, isNdeliusId } from '../utils/idHelpers'
 import { dataAccess } from '../data'
+import getUserId from '../utils/userIdHelper'
 
 export default class SummaryController {
   static getReportDetails(req: Request, res: Response) {
@@ -21,19 +22,17 @@ export default class SummaryController {
     })
   }
 
-  static async getUserToken() {
-    const token = await dataAccess().hmppsAuthClient.getSystemClientToken()
-    return token
-  }
-
   static async postReportDetails(req: Request, res: Response) {
-    const token = await SummaryController.getUserToken()
+    const token = await SummaryController.getSystemToken()
     const userData = req.session.userData ?? {}
     const list: string[] = []
     const servicelist = req.session.selectedList
+    const requestedBy = getUserId(req)
+
     if (dataAccess().telemetryClient) {
       dataAccess().telemetryClient.trackEvent({ name: 'postReportDetails', properties: { id: userData.subjectId } })
     }
+
     for (let i = 0; i < servicelist.length; i += 1) {
       list.push(`${servicelist[i].text}, ${servicelist[i].urls}`)
     }
@@ -44,6 +43,7 @@ export default class SummaryController {
     } else if (isNdeliusId(userData.subjectId)) {
       ndeliusId = userData.subjectId
     }
+
     try {
       const response = await superagent
         .post(`${config.apis.subjectAccessRequest.url}/api/createSubjectAccessRequest`)
@@ -55,6 +55,7 @@ export default class SummaryController {
           services: list.toString(),
           nomisId,
           ndeliusId,
+          requestedBy,
         })
       res.redirect('/confirmation')
       return response
@@ -65,5 +66,10 @@ export default class SummaryController {
       }
       throw error
     }
+  }
+
+  static async getSystemToken() {
+    const token = await dataAccess().hmppsAuthClient.getSystemClientToken()
+    return token
   }
 }

--- a/server/controllers/summaryController.ts
+++ b/server/controllers/summaryController.ts
@@ -45,20 +45,24 @@ export default class SummaryController {
     }
 
     try {
-      const response = await superagent
-        .post(`${config.apis.subjectAccessRequest.url}/api/createSubjectAccessRequest`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          dateFrom: userData.dateFrom,
-          dateTo: userData.dateTo,
-          sarCaseReferenceNumber: userData.caseReference,
-          services: list.toString(),
-          nomisId,
-          ndeliusId,
-          requestedBy,
-        })
-      res.redirect('/confirmation')
-      return response
+      if (requestedBy == null) {
+        throw new Error('Could not identify SAR requestor. RequestedBy field is null.')
+      } else {
+        const response = await superagent
+          .post(`${config.apis.subjectAccessRequest.url}/api/createSubjectAccessRequest`)
+          .set('Authorization', `Bearer ${token}`)
+          .send({
+            dateFrom: userData.dateFrom,
+            dateTo: userData.dateTo,
+            sarCaseReferenceNumber: userData.caseReference,
+            services: list.toString(),
+            nomisId,
+            ndeliusId,
+            requestedBy,
+          })
+        res.redirect('/confirmation')
+        return response
+      }
     } catch (error) {
       if (error.status === 404) {
         // error.status >= 400 && error.status < 500) {

--- a/server/data/serviceCatalogueClient.ts
+++ b/server/data/serviceCatalogueClient.ts
@@ -3,14 +3,14 @@ import config from '../config'
 import { dataAccess } from '.'
 
 export default class ServiceCatalogueClient {
-  static async getUserToken() {
+  static async getSystemToken() {
     const token = await dataAccess().hmppsAuthClient.getSystemClientToken()
     return token
   }
 
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   async getServiceList(): Promise<any> {
-    const token = await ServiceCatalogueClient.getUserToken()
+    const token = await ServiceCatalogueClient.getSystemToken()
     try {
       const response = await superagent
         .get(`${config.apis.serviceCatalogue.url}/sar-report-components?env=${config.apis.serviceCatalogue.env}`)

--- a/server/utils/userIdHelper.test.ts
+++ b/server/utils/userIdHelper.test.ts
@@ -1,0 +1,20 @@
+import { type Request } from 'express'
+import getUserId from './userIdHelper'
+
+describe('userIdHelper', () => {
+  describe('getUserId', () => {
+    test('returns userId extracted from user token', () => {
+      const req: Request = {
+        // @ts-expect-error stubbing session
+        session: {},
+        user: {
+          token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3V1aWQiOiJtb2NrZWRVc2VySWQiLCJuYW1lIjoiRXhhbXBsZSBVc2VyIn0.KcjDfjwlAS8Jlz7swp-X2FlSyRAFtEKvQ6WuzLSzAaU',
+          authSource: 'auth',
+        },
+      }
+      const userId = getUserId(req)
+      expect(userId).toEqual('mockedUserId')
+    })
+  })
+})

--- a/server/utils/userIdHelper.ts
+++ b/server/utils/userIdHelper.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express'
+import { jwtDecode } from 'jwt-decode'
+
+const getUserId = (req: Request) => {
+  let requestedBy = null
+
+  const userToken = req.user.token
+  const decodedUserToken = jwtDecode(userToken)
+  if ('user_uuid' in decodedUserToken) {
+    requestedBy = decodedUserToken.user_uuid
+  } else if ('user_id' in decodedUserToken) {
+    requestedBy = decodedUserToken.user_id
+  }
+  return requestedBy
+}
+
+export default getUserId


### PR DESCRIPTION
## Context
The SAR database's RequestedBy field and the message we send to the audit service currently lists the SAR Frontend as the person carrying out actions on the API. We need the audit service to have the actual username of the person interacting with the system.

## Changes proposed in this PR
This PR extracts the user's ID from their auth token stored as part of the session data, as per [SR131](https://dsdmoj.atlassian.net/browse/SR-131).

## Next steps
- Update the SAR API so that the requestedBy data is stored correctly in the SAR database
- Update the SAR API so that the requestedBy data is sent to the Audit service
- Review how users authenticate with the SAR service