### PR TITLE
Download link

### DIFF
--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -16,14 +16,14 @@ beforeEach(() => {
         dateOfRequest: '2023-01-19',
         sarCaseReference: 'example2',
         subjectId: 'C2345BB',
-        status: 'Complete',
+        status: 'Completed',
       },
       {
         uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
         dateOfRequest: '2022-16-18',
         sarCaseReference: 'example3',
         subjectId: 'D3456CC',
-        status: 'Complete',
+        status: 'Completed',
       },
     ],
     numberOfReports: 3,
@@ -60,14 +60,14 @@ describe('getReports', () => {
           {
             dateOfRequest: '2023-01-19',
             sarCaseReference: 'example2',
-            status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
+            status: 'Completed',
             subjectId: 'C2345BB',
             uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
           },
           {
             dateOfRequest: '2022-16-18',
             sarCaseReference: 'example3',
-            status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
+            status: 'Completed',
             subjectId: 'D3456CC',
             uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
           },
@@ -248,64 +248,6 @@ describe('getReports', () => {
           'pages/reports',
           expect.objectContaining({
             numberOfReports: 240,
-          }),
-        )
-      })
-
-      test('if status is "Complete", a link to download report is used', () => {
-        ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue({
-          reports: [
-            {
-              uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
-              dateOfRequest: '2024-12-20',
-              sarCaseReference: 'example1',
-              subjectId: 'B1234AA',
-              status: 'Pending',
-            },
-            {
-              uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
-              dateOfRequest: '2023-01-19',
-              sarCaseReference: 'example2',
-              subjectId: 'C2345BB',
-              status: 'Complete',
-            },
-            {
-              uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
-              dateOfRequest: '2022-16-18',
-              sarCaseReference: 'example3',
-              subjectId: 'D3456CC',
-              status: 'Complete',
-            },
-          ],
-          numberOfReports: 3,
-        })
-        ReportsController.getReports(req, res)
-        expect(res.render).toBeCalledWith(
-          'pages/reports',
-          expect.objectContaining({
-            reportList: [
-              {
-                dateOfRequest: '2024-12-20',
-                sarCaseReference: 'example1',
-                status: 'Pending',
-                subjectId: 'B1234AA',
-                uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
-              },
-              {
-                dateOfRequest: '2023-01-19',
-                sarCaseReference: 'example2',
-                status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
-                subjectId: 'C2345BB',
-                uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
-              },
-              {
-                dateOfRequest: '2022-16-18',
-                sarCaseReference: 'example3',
-                status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
-                subjectId: 'D3456CC',
-                uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
-              },
-            ],
           }),
         )
       })

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -60,14 +60,14 @@ describe('getReports', () => {
           {
             dateOfRequest: '2023-01-19',
             sarCaseReference: 'example2',
-            status: 'Complete',
+            status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
             subjectId: 'C2345BB',
             uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
           },
           {
             dateOfRequest: '2022-16-18',
             sarCaseReference: 'example3',
-            status: 'Complete',
+            status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
             subjectId: 'D3456CC',
             uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
           },
@@ -248,6 +248,64 @@ describe('getReports', () => {
           'pages/reports',
           expect.objectContaining({
             numberOfReports: 240,
+          }),
+        )
+      })
+
+      test('if status is "Complete", a link to download report is used', () => {
+        ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue({
+          reports: [
+            {
+              uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+              dateOfRequest: '2024-12-20',
+              sarCaseReference: 'example1',
+              subjectId: 'B1234AA',
+              status: 'Pending',
+            },
+            {
+              uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+              dateOfRequest: '2023-01-19',
+              sarCaseReference: 'example2',
+              subjectId: 'C2345BB',
+              status: 'Complete',
+            },
+            {
+              uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+              dateOfRequest: '2022-16-18',
+              sarCaseReference: 'example3',
+              subjectId: 'D3456CC',
+              status: 'Complete',
+            },
+          ],
+          numberOfReports: 3,
+        })
+        ReportsController.getReports(req, res)
+        expect(res.render).toBeCalledWith(
+          'pages/reports',
+          expect.objectContaining({
+            reportList: [
+              {
+                dateOfRequest: '2024-12-20',
+                sarCaseReference: 'example1',
+                status: 'Pending',
+                subjectId: 'B1234AA',
+                uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+              },
+              {
+                dateOfRequest: '2023-01-19',
+                sarCaseReference: 'example2',
+                status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
+                subjectId: 'C2345BB',
+                uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+              },
+              {
+                dateOfRequest: '2022-16-18',
+                sarCaseReference: 'example3',
+                status: '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>',
+                subjectId: 'D3456CC',
+                uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+              },
+            ],
           }),
         )
       })

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -20,14 +20,14 @@ export default class ReportsController {
         dateOfRequest: '2023-07-30',
         sarCaseReference: '2-casereference',
         subjectId: 'B2345BB',
-        status: 'Complete',
+        status: 'Completed',
       },
       {
         uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
         dateOfRequest: '2022-12-30',
         sarCaseReference: '3-casereference',
         subjectId: 'C3456CC',
-        status: 'Complete',
+        status: 'Completed',
       },
     ]
     return { reports, numberOfReports }
@@ -48,11 +48,6 @@ export default class ReportsController {
 
     const pageLinks = getPageLinks({ visiblePageLinks, numberOfPages, currentPage: parsedPage })
 
-    reports.forEach(report => {
-      if (report.status === 'Complete') {
-        report.status = '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>' // eslint-disable-line no-param-reassign
-      }
-    })
     res.render('pages/reports', {
       reportList: reports,
       pageLinks,

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -48,6 +48,11 @@ export default class ReportsController {
 
     const pageLinks = getPageLinks({ visiblePageLinks, numberOfPages, currentPage: parsedPage })
 
+    reports.forEach(report => {
+      if (report.status === 'Complete') {
+        report.status = '<a href="/download" class="govuk-body govuk-link" id="download-report">View report</a>' // eslint-disable-line no-param-reassign
+      }
+    })
     res.render('pages/reports', {
       reportList: reports,
       pageLinks,

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -40,12 +40,21 @@
       </thead>
       <tbody class="govuk-table__body">
         {% for report in reportList %}
+          {% if report.status == 'Completed' %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{report.dateOfRequest}}</td>
+                    <td class="govuk-table__cell">{{report.sarCaseReference}}</td>
+                    <td class="govuk-table__cell">{{report.subjectId}}</td>
+                    <td class="govuk-table__cell"><a href="/download" class="govuk-body govuk-link" /a>View report</td>
+                </tr>
+          {% else %}
                 <tr class="govuk-table__row">
                     <td class="govuk-table__cell">{{report.dateOfRequest}}</td>
                     <td class="govuk-table__cell">{{report.sarCaseReference}}</td>
                     <td class="govuk-table__cell">{{report.subjectId}}</td>
                     <td class="govuk-table__cell">{{report.status}}</td>
                 </tr>
+          {% endif %}
             {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
This adds a link to the reports page for reports with status "Completed". The link currently doesn't work, but will be properly implemented when the API endpoint for downloading a report is in place.

<img width="1379" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-ui/assets/67278233/31437983-a871-4257-b9af-b5f6e5324fb6">
<img width="1408" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-ui/assets/67278233/fe3afa65-4ac3-4da9-a742-ca869ed9d3e6">
