### PR TITLE
Add call to API endpoint to get reports info.

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,6 +5,7 @@ import manageUsersApi from './integration_tests/mockApis/manageUsersApi'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import stubServiceList from './integration_tests/mockApis/serviceCatalogue'
 import stubCreateSubjectAccessRequest from './integration_tests/mockApis/createSubjectAccessRequest'
+import stubGetReports from './integration_tests/mockApis/reports'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -27,6 +28,7 @@ export default defineConfig({
         ...tokenVerification,
         stubServiceList,
         stubCreateSubjectAccessRequest,
+        stubGetReports,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/e2e/reports.cy.ts
+++ b/integration_tests/e2e/reports.cy.ts
@@ -7,6 +7,7 @@ context('Reports', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubManageUser')
+    cy.task('stubGetReports', 200)
   })
 
   it('Redirects to auth if requested by unauthenticated user', () => {

--- a/integration_tests/e2e/reports.cy.ts
+++ b/integration_tests/e2e/reports.cy.ts
@@ -7,7 +7,29 @@ context('Reports', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubManageUser')
-    cy.task('stubGetReports', 200)
+    cy.task('stubGetReports', [
+      {
+        uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+        dateOfRequest: '2024-12-01',
+        sarCaseReference: '1-casereference',
+        subjectId: 'A1234AA',
+        status: 'Pending',
+      },
+      {
+        uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+        dateOfRequest: '2023-07-30',
+        sarCaseReference: '2-casereference',
+        subjectId: 'B2345BB',
+        status: 'Completed',
+      },
+      {
+        uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+        dateOfRequest: '2022-12-30',
+        sarCaseReference: '3-casereference',
+        subjectId: 'C3456CC',
+        status: 'Completed',
+      },
+    ])
   })
 
   it('Redirects to auth if requested by unauthenticated user', () => {

--- a/integration_tests/mockApis/reports.ts
+++ b/integration_tests/mockApis/reports.ts
@@ -1,0 +1,15 @@
+import { stubFor } from './wiremock'
+
+const stubGetReports = responseStatus => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/api/reports',
+    },
+    response: {
+      status: responseStatus,
+    },
+  })
+}
+
+export default stubGetReports

--- a/integration_tests/mockApis/reports.ts
+++ b/integration_tests/mockApis/reports.ts
@@ -4,7 +4,7 @@ const stubGetReports = responseBody => {
   return stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/api/reports',
+      urlPattern: '/api/reports\\?pageSize=50&pageNumber=1',
     },
     response: {
       status: 200,

--- a/integration_tests/mockApis/reports.ts
+++ b/integration_tests/mockApis/reports.ts
@@ -1,13 +1,17 @@
 import { stubFor } from './wiremock'
 
-const stubGetReports = responseStatus => {
+const stubGetReports = responseBody => {
   return stubFor({
     request: {
       method: 'GET',
       urlPattern: '/api/reports',
     },
     response: {
-      status: responseStatus,
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;',
+      },
+      jsonBody: responseBody,
     },
   })
 }

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -1,7 +1,12 @@
 import type { Request, Response } from 'express'
+import nock from 'nock'
 import ReportsController from './reportsController'
+import config from '../config'
+
+let fakeApi: nock.Scope
 
 beforeEach(() => {
+  fakeApi = nock(config.apis.subjectAccessRequest.url)
   ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue({
     reports: [
       {
@@ -44,8 +49,8 @@ describe('getReports', () => {
   const res: Response = {
     render: jest.fn(),
   }
-  test('renders a response with list of SAR reports', () => {
-    ReportsController.getReports(req, res)
+  test('renders a response with list of SAR reports', async () => {
+    await ReportsController.getReports(req, res)
     expect(res.render).toBeCalledWith(
       'pages/reports',
       expect.objectContaining({
@@ -84,8 +89,8 @@ describe('getReports', () => {
       })
     })
     describe('when the current page is the first page', () => {
-      test('previous will be 0 and so will not appear', () => {
-        ReportsController.getReports(req, res)
+      test('previous will be 0 and so will not appear', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -94,8 +99,8 @@ describe('getReports', () => {
         )
       })
 
-      test('next directs to second page', () => {
-        ReportsController.getReports(req, res)
+      test('next directs to second page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -104,8 +109,8 @@ describe('getReports', () => {
         )
       })
 
-      test('from gives the first number of the range of displayed results on the page', () => {
-        ReportsController.getReports(req, res)
+      test('from gives the first number of the range of displayed results on the page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -114,8 +119,8 @@ describe('getReports', () => {
         )
       })
 
-      test('to gives the last number of the range of displayed results on the page', () => {
-        ReportsController.getReports(req, res)
+      test('to gives the last number of the range of displayed results on the page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -124,8 +129,8 @@ describe('getReports', () => {
         )
       })
 
-      test('numberOfReports gives the total number of reports', () => {
-        ReportsController.getReports(req, res)
+      test('numberOfReports gives the total number of reports', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -143,8 +148,8 @@ describe('getReports', () => {
           query: { page: '5' },
         }
       })
-      test('previous directs to the fourth page', () => {
-        ReportsController.getReports(req, res)
+      test('previous directs to the fourth page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -153,8 +158,8 @@ describe('getReports', () => {
         )
       })
 
-      test('next will be 0 and so will not appear', () => {
-        ReportsController.getReports(req, res)
+      test('next will be 0 and so will not appear', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -163,8 +168,8 @@ describe('getReports', () => {
         )
       })
 
-      test('from gives the first number of the range of displayed results on the page', () => {
-        ReportsController.getReports(req, res)
+      test('from gives the first number of the range of displayed results on the page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -173,8 +178,8 @@ describe('getReports', () => {
         )
       })
 
-      test('to gives the last number of the range of displayed results on the page', () => {
-        ReportsController.getReports(req, res)
+      test('to gives the last number of the range of displayed results on the page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -183,8 +188,8 @@ describe('getReports', () => {
         )
       })
 
-      test('numberOfReports gives the total number of reports', () => {
-        ReportsController.getReports(req, res)
+      test('numberOfReports gives the total number of reports', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -202,8 +207,8 @@ describe('getReports', () => {
           query: { page: '3' },
         }
       })
-      test('previous directs to the second page', () => {
-        ReportsController.getReports(req, res)
+      test('previous directs to the second page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -212,8 +217,8 @@ describe('getReports', () => {
         )
       })
 
-      test('next directs to fourth page', () => {
-        ReportsController.getReports(req, res)
+      test('next directs to fourth page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -222,8 +227,8 @@ describe('getReports', () => {
         )
       })
 
-      test('from gives the first number of the range of displayed results on the page', () => {
-        ReportsController.getReports(req, res)
+      test('from gives the first number of the range of displayed results on the page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -232,8 +237,8 @@ describe('getReports', () => {
         )
       })
 
-      test('to gives the last number of the range of displayed results on the page', () => {
-        ReportsController.getReports(req, res)
+      test('to gives the last number of the range of displayed results on the page', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -242,8 +247,8 @@ describe('getReports', () => {
         )
       })
 
-      test('numberOfReports gives the total number of reports', () => {
-        ReportsController.getReports(req, res)
+      test('numberOfReports gives the total number of reports', async () => {
+        await ReportsController.getReports(req, res)
         expect(res.render).toBeCalledWith(
           'pages/reports',
           expect.objectContaining({
@@ -251,6 +256,35 @@ describe('getReports', () => {
           }),
         )
       })
+    })
+  })
+  describe('report info', () => {
+    test('getSubjectAccessRequestList gets correct response', async () => {
+      fakeApi.get('/api/reports').reply(200, [
+        {
+          uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+          dateOfRequest: '2024-12-20',
+          sarCaseReference: 'example1',
+          subjectId: 'B1234AA',
+          status: 'Pending',
+        },
+        {
+          uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+          dateOfRequest: '2023-01-19',
+          sarCaseReference: 'example2',
+          subjectId: 'C2345BB',
+          status: 'Completed',
+        },
+        {
+          uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+          dateOfRequest: '2022-16-18',
+          sarCaseReference: 'example3',
+          subjectId: 'D3456CC',
+          status: 'Completed',
+        },
+      ])
+      const response = await ReportsController.getSubjectAccessRequestList()
+      expect(response.numberOfReports).toBe(3)
     })
   })
 })

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -283,7 +283,7 @@ describe('getReports', () => {
           status: 'Completed',
         },
       ])
-      const response = await ReportsController.getSubjectAccessRequestList('1')
+      const response = await ReportsController.getSubjectAccessRequestList()
       expect(response.numberOfReports).toBe(3)
     })
   })

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -260,7 +260,7 @@ describe('getReports', () => {
   })
   describe('report info', () => {
     test('getSubjectAccessRequestList gets correct response', async () => {
-      fakeApi.get('/api/reports').reply(200, [
+      fakeApi.get('/api/reports?pageSize=50&pageNumber=1').reply(200, [
         {
           uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
           dateOfRequest: '2024-12-20',

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -283,7 +283,7 @@ describe('getReports', () => {
           status: 'Completed',
         },
       ])
-      const response = await ReportsController.getSubjectAccessRequestList()
+      const response = await ReportsController.getSubjectAccessRequestList('1')
       expect(response.numberOfReports).toBe(3)
     })
   })

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -5,12 +5,13 @@ import config from '../config'
 import { dataAccess } from '../data'
 
 const RESULTSPERPAGE = 50
+let currentPage = '0'
 
 export default class ReportsController {
-  static async getSubjectAccessRequestList(page: string) {
+  static async getSubjectAccessRequestList() {
     const token = await ReportsController.getSystemToken()
     const response = await superagent
-      .get(`${config.apis.subjectAccessRequest.url}/api/reports?pageSize=${RESULTSPERPAGE}&pageNumber=${page}`)
+      .get(`${config.apis.subjectAccessRequest.url}/api/reports?pageSize=${RESULTSPERPAGE}&pageNumber=${currentPage}`)
       .set('Authorization', `Bearer ${token}`)
     const numberOfReports = response.body.length
     const reports = response.body
@@ -44,8 +45,8 @@ export default class ReportsController {
   }
 
   static async getReports(req: Request, res: Response) {
-    const currentPage = (req.query.page || '1') as string
-    const { reports, numberOfReports } = await ReportsController.getSubjectAccessRequestList(currentPage)
+    currentPage = (req.query.page || '1') as string
+    const { reports, numberOfReports } = await ReportsController.getSubjectAccessRequestList()
     const parsedPage = Number.parseInt(currentPage, 10) || 1
     const visiblePageLinks = 5
     const numberOfPages = Math.ceil(numberOfReports / RESULTSPERPAGE)

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -2,12 +2,16 @@ import type { Request, Response } from 'express'
 import superagent from 'superagent'
 import getPageLinks from '../utils/paginationHelper'
 import config from '../config'
+import { dataAccess } from '../data'
 
 const RESULTSPERPAGE = 50
 
 export default class ReportsController {
   static async getSubjectAccessRequestList() {
-    const response = await superagent.get(`${config.apis.subjectAccessRequest.url}/api/reports`)
+    const token = await ReportsController.getSystemToken()
+    const response = await superagent
+      .get(`${config.apis.subjectAccessRequest.url}/api/reports`)
+      .set('Authorization', `Bearer ${token}`)
     const numberOfReports = response.body.length
     const reports = response.body
 
@@ -62,5 +66,10 @@ export default class ReportsController {
       to,
       numberOfReports,
     })
+  }
+
+  static async getSystemToken() {
+    const token = await dataAccess().hmppsAuthClient.getSystemClientToken()
+    return token
   }
 }

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -16,31 +16,6 @@ export default class ReportsController {
     const numberOfReports = response.body.length
     const reports = response.body
 
-    // const numberOfReports = 500
-    // const reports = [
-    //   {
-    //     uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
-    //     dateOfRequest: '2024-12-01',
-    //     sarCaseReference: '1-casereference',
-    //     subjectId: 'A1234AA',
-    //     status: 'Pending',
-    //   },
-    //   {
-    //     uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
-    //     dateOfRequest: '2023-07-30',
-    //     sarCaseReference: '2-casereference',
-    //     subjectId: 'B2345BB',
-    //     status: 'Completed',
-    //   },
-    //   {
-    //     uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
-    //     dateOfRequest: '2022-12-30',
-    //     sarCaseReference: '3-casereference',
-    //     subjectId: 'C3456CC',
-    //     status: 'Completed',
-    //   },
-    // ]
-
     return { reports, numberOfReports }
   }
 

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -7,10 +7,10 @@ import { dataAccess } from '../data'
 const RESULTSPERPAGE = 50
 
 export default class ReportsController {
-  static async getSubjectAccessRequestList() {
+  static async getSubjectAccessRequestList(page: string) {
     const token = await ReportsController.getSystemToken()
     const response = await superagent
-      .get(`${config.apis.subjectAccessRequest.url}/api/reports`)
+      .get(`${config.apis.subjectAccessRequest.url}/api/reports?pageSize=${RESULTSPERPAGE}&pageNumber=${page}`)
       .set('Authorization', `Bearer ${token}`)
     const numberOfReports = response.body.length
     const reports = response.body
@@ -44,8 +44,8 @@ export default class ReportsController {
   }
 
   static async getReports(req: Request, res: Response) {
-    const { reports, numberOfReports } = await ReportsController.getSubjectAccessRequestList()
     const currentPage = (req.query.page || '1') as string
+    const { reports, numberOfReports } = await ReportsController.getSubjectAccessRequestList(currentPage)
     const parsedPage = Number.parseInt(currentPage, 10) || 1
     const visiblePageLinks = 5
     const numberOfPages = Math.ceil(numberOfReports / RESULTSPERPAGE)

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -9,6 +9,7 @@ let currentPage = '1'
 
 export default class ReportsController {
   static async getSubjectAccessRequestList() {
+    // This should be user token once implemented
     const token = await ReportsController.getSystemToken()
     const response = await superagent
       .get(`${config.apis.subjectAccessRequest.url}/api/reports?pageSize=${RESULTSPERPAGE}&pageNumber=${currentPage}`)

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -5,7 +5,7 @@ import config from '../config'
 import { dataAccess } from '../data'
 
 const RESULTSPERPAGE = 50
-let currentPage = '0'
+let currentPage = '1'
 
 export default class ReportsController {
   static async getSubjectAccessRequestList() {

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -1,40 +1,46 @@
 import type { Request, Response } from 'express'
+import superagent from 'superagent'
 import getPageLinks from '../utils/paginationHelper'
+import config from '../config'
 
 const RESULTSPERPAGE = 50
 
 export default class ReportsController {
-  static getSubjectAccessRequestList() {
-    const numberOfReports = 500
+  static async getSubjectAccessRequestList() {
+    const response = await superagent.get(`${config.apis.subjectAccessRequest.url}/api/reports`)
+    const numberOfReports = response.body.length
+    const reports = response.body
 
-    const reports = [
-      {
-        uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
-        dateOfRequest: '2024-12-01',
-        sarCaseReference: '1-casereference',
-        subjectId: 'A1234AA',
-        status: 'Pending',
-      },
-      {
-        uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
-        dateOfRequest: '2023-07-30',
-        sarCaseReference: '2-casereference',
-        subjectId: 'B2345BB',
-        status: 'Completed',
-      },
-      {
-        uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
-        dateOfRequest: '2022-12-30',
-        sarCaseReference: '3-casereference',
-        subjectId: 'C3456CC',
-        status: 'Completed',
-      },
-    ]
+    // const numberOfReports = 500
+    // const reports = [
+    //   {
+    //     uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+    //     dateOfRequest: '2024-12-01',
+    //     sarCaseReference: '1-casereference',
+    //     subjectId: 'A1234AA',
+    //     status: 'Pending',
+    //   },
+    //   {
+    //     uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+    //     dateOfRequest: '2023-07-30',
+    //     sarCaseReference: '2-casereference',
+    //     subjectId: 'B2345BB',
+    //     status: 'Completed',
+    //   },
+    //   {
+    //     uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+    //     dateOfRequest: '2022-12-30',
+    //     sarCaseReference: '3-casereference',
+    //     subjectId: 'C3456CC',
+    //     status: 'Completed',
+    //   },
+    // ]
+
     return { reports, numberOfReports }
   }
 
-  static getReports(req: Request, res: Response) {
-    const { reports, numberOfReports } = ReportsController.getSubjectAccessRequestList()
+  static async getReports(req: Request, res: Response) {
+    const { reports, numberOfReports } = await ReportsController.getSubjectAccessRequestList()
     const currentPage = (req.query.page || '1') as string
     const parsedPage = Number.parseInt(currentPage, 10) || 1
     const visiblePageLinks = 5
@@ -47,7 +53,6 @@ export default class ReportsController {
     const to = Math.min(parsedPage * RESULTSPERPAGE, numberOfReports)
 
     const pageLinks = getPageLinks({ visiblePageLinks, numberOfPages, currentPage: parsedPage })
-
     res.render('pages/reports', {
       reportList: reports,
       pageLinks,

--- a/server/controllers/summaryController.ts
+++ b/server/controllers/summaryController.ts
@@ -23,7 +23,6 @@ export default class SummaryController {
   }
 
   static async postReportDetails(req: Request, res: Response) {
-    // This should be user token once implemented
     const token = await SummaryController.getSystemToken()
     const userData = req.session.userData ?? {}
     const list: string[] = []

--- a/server/controllers/summaryController.ts
+++ b/server/controllers/summaryController.ts
@@ -23,6 +23,7 @@ export default class SummaryController {
   }
 
   static async postReportDetails(req: Request, res: Response) {
+    // This should be user token once implemented
     const token = await SummaryController.getSystemToken()
     const userData = req.session.userData ?? {}
     const list: string[] = []

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -2,6 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 import { appWithAllRoutes } from './testutils/appSetup'
 import ServiceSelectionController from '../controllers/serviceSelectionController'
+import ReportsController from '../controllers/reportsController'
 
 let app: Express
 
@@ -20,6 +21,32 @@ beforeEach(() => {
       environments: [{ id: 47270, url: 'https://prisoner-search-indexer-dev.prison.service.justice.gov.uk' }],
     },
   ])
+  ReportsController.getSubjectAccessRequestList = jest.fn().mockReturnValue({
+    reports: [
+      {
+        uuid: 'ae6f396d-f1b1-460b-8d13-9a5f3e569c1a',
+        dateOfRequest: '2024-12-20',
+        sarCaseReference: 'example1',
+        subjectId: 'B1234AA',
+        status: 'Pending',
+      },
+      {
+        uuid: '1e130369-f3fb-46ab-8855-abd621d0b032',
+        dateOfRequest: '2023-01-19',
+        sarCaseReference: 'example2',
+        subjectId: 'C2345BB',
+        status: 'Completed',
+      },
+      {
+        uuid: '756689d0-4a0b-405c-bf0c-312f11f9f1b7',
+        dateOfRequest: '2022-16-18',
+        sarCaseReference: 'example3',
+        subjectId: 'D3456CC',
+        status: 'Completed',
+      },
+    ],
+    numberOfReports: 3,
+  })
 })
 
 afterEach(() => {


### PR DESCRIPTION
This PR means that the Reports page actually gets the real reports from the database, by calling the API /reports endpoint with 'pageSize' and 'pageNumber' parameters.

I would like feedback on the current way of getting the pageNumber to the point where the endpoint is called. I've made use of the `RESULTSPERPAGE` global variable for pageSize, and have ended up implementing something similar for pageNumber. 
If you pass a pageNumber as a parameter to getSubjectAccessRequestList you can't stub the response for that function with Wiremock.
I tried to add a `getCurrentPage` function which could be accessed from getSubjectAccessRequestList but the function doesn't have access to `req`. 

I also don't love that the stub has hard-coded values for the test case.