### PR TITLE
Update createSAR endpoint URL

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ import auth from './integration_tests/mockApis/auth'
 import manageUsersApi from './integration_tests/mockApis/manageUsersApi'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import stubServiceList from './integration_tests/mockApis/serviceCatalogue'
-import stubCreateSubjectAccessRequest from './integration_tests/mockApis/createSubjectAccessRequest'
+import stubSubjectAccessRequest from './integration_tests/mockApis/subjectAccessRequest'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -26,7 +26,7 @@ export default defineConfig({
         ...manageUsersApi,
         ...tokenVerification,
         stubServiceList,
-        stubCreateSubjectAccessRequest,
+        stubSubjectAccessRequest,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/e2e/summary.cy.ts
+++ b/integration_tests/e2e/summary.cy.ts
@@ -206,7 +206,7 @@ context('Summary', () => {
   // The below test fails because the backend isn't running and so the confirmation page
   // doesn't render. I'm not sure how to test this.
   it('Redirects to /confirmation on clicking submit button', () => {
-    cy.task('stubCreateSubjectAccessRequest', 201)
+    cy.task('stubSubjectAccessRequest', 201)
     cy.intercept({
       method: 'POST',
       url: '/summary',

--- a/integration_tests/mockApis/subjectAccessRequest.ts
+++ b/integration_tests/mockApis/subjectAccessRequest.ts
@@ -1,10 +1,10 @@
 import { stubFor } from './wiremock'
 
-const stubCreateSubjectAccessRequest = responseStatus => {
+const stubSubjectAccessRequest = responseStatus => {
   return stubFor({
     request: {
       method: 'POST',
-      urlPattern: '/api/createSubjectAccessRequest',
+      urlPattern: '/api/subjectAccessRequest',
     },
     response: {
       status: responseStatus,
@@ -12,4 +12,4 @@ const stubCreateSubjectAccessRequest = responseStatus => {
   })
 }
 
-export default stubCreateSubjectAccessRequest
+export default stubSubjectAccessRequest

--- a/server/controllers/summaryController.test.ts
+++ b/server/controllers/summaryController.test.ts
@@ -55,7 +55,7 @@ describe('postReportDetails', () => {
     redirect: jest.fn(),
   }
 
-  test('post request made to createSubjectAccessRequest endpoint renders confirmation page if successful', async () => {
+  test('post request made to SubjectAccessRequest endpoint renders confirmation page if successful', async () => {
     const req: Request = {
       // @ts-expect-error stubbing session
       session: {
@@ -76,7 +76,7 @@ describe('postReportDetails', () => {
 
     fakeApi
       .post(
-        '/api/createSubjectAccessRequest',
+        '/api/subjectAccessRequest',
         '{"dateFrom":"01/01/2001","dateTo":"25/12/2022","sarCaseReferenceNumber":"mockedCaseReference","services":"service1, .com","nomisId":"A1111AA","ndeliusId":"","requestedBy":"mockedUserId"}',
       )
       .reply(200)
@@ -107,7 +107,7 @@ describe('postReportDetails', () => {
     }
     nock(config.apis.subjectAccessRequest.url)
       .post(
-        '/api/createSubjectAccessRequest',
+        '/api/subjectAccessRequest',
         '{"dateFrom":"01/01/2001","dateTo":"25/12/2022","sarCaseReferenceNumber":"mockedCaseReference","services":"service1, .com","nomisId":"","ndeliusId":"","requestedBy":"mockedUserId"}',
       )
       .reply(400)

--- a/server/controllers/summaryController.ts
+++ b/server/controllers/summaryController.ts
@@ -49,7 +49,7 @@ export default class SummaryController {
         throw new Error('Could not identify SAR requestor. RequestedBy field is null.')
       } else {
         const response = await superagent
-          .post(`${config.apis.subjectAccessRequest.url}/api/createSubjectAccessRequest`)
+          .post(`${config.apis.subjectAccessRequest.url}/api/subjectAccessRequest`)
           .set('Authorization', `Bearer ${token}`)
           .send({
             dateFrom: userData.dateFrom,


### PR DESCRIPTION
- Following a rename of POST /createSubjectAccessRequest to POST /subjectAccessRequest in the SAR API