### PR TITLE
Add back links to request report journey

### DIFF
--- a/integration_tests/e2e/inputs.cy.ts
+++ b/integration_tests/e2e/inputs.cy.ts
@@ -202,4 +202,12 @@ context('Inputs', () => {
     cy.wait('@saveInputs')
     cy.url().should('to.match', /inputs$/)
   })
+
+  it('redirects to subject ID page when back link is clicked', () => {
+    cy.signIn()
+    cy.visit('/inputs')
+    const inputsPage = Page.verifyOnPage(InputsPage)
+    inputsPage.backLink().click()
+    Page.verifyOnPage(SubjectIdPage)
+  })
 })

--- a/integration_tests/e2e/serviceSelection.cy.ts
+++ b/integration_tests/e2e/serviceSelection.cy.ts
@@ -1,6 +1,7 @@
 import Page from '../pages/page'
 import ServiceSelectionPage from '../pages/serviceSelection'
 import AuthSignInPage from '../pages/authSignIn'
+import InputsPage from '../pages/inputs'
 
 context('ServiceSelection', () => {
   beforeEach(() => {
@@ -81,5 +82,13 @@ context('ServiceSelection', () => {
     cy.visit('/service-selection')
     const serviceSelectionPage = Page.verifyOnPage(ServiceSelectionPage)
     serviceSelectionPage.errorSummaryBox().should('be.visible')
+  })
+
+  it('redirects to inputs page when back link is clicked', () => {
+    cy.signIn()
+    cy.visit('/service-selection')
+    const serviceSelectionPage = Page.verifyOnPage(ServiceSelectionPage)
+    serviceSelectionPage.backLink().click()
+    Page.verifyOnPage(InputsPage)
   })
 })

--- a/integration_tests/e2e/subjectId.cy.ts
+++ b/integration_tests/e2e/subjectId.cy.ts
@@ -2,6 +2,7 @@ import Page from '../pages/page'
 import AuthSignInPage from '../pages/authSignIn'
 import SubjectIdPage from '../pages/subjectId'
 import InputsPage from '../pages/inputs'
+import IndexPage from '../pages'
 
 context('SubjectId', () => {
   beforeEach(() => {
@@ -80,5 +81,13 @@ context('SubjectId', () => {
     cy.url().should('to.match', /subject-id$/)
     subjectIdPage = Page.verifyOnPage(SubjectIdPage)
     subjectIdPage.errorSummaryBox().should('exist')
+  })
+
+  it('redirects to homepage when back link is clicked', () => {
+    cy.signIn()
+    cy.visit('/subject-id')
+    const subjectIdPage = Page.verifyOnPage(SubjectIdPage)
+    subjectIdPage.backLink().click()
+    Page.verifyOnPage(IndexPage)
   })
 })

--- a/integration_tests/pages/inputs.ts
+++ b/integration_tests/pages/inputs.ts
@@ -14,4 +14,6 @@ export default class InputsPage extends Page {
   caseReferenceTextbox = (): PageElement => cy.get('#input-caseReference')
 
   continueButton = (): PageElement => cy.get('#input-continue')
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 }

--- a/integration_tests/pages/serviceSelection.ts
+++ b/integration_tests/pages/serviceSelection.ts
@@ -10,4 +10,6 @@ export default class ServiceSelectionPage extends Page {
   checkAllCheckBox = (): PageElement => cy.get('#checkboxes-all')
 
   submitButton = (): PageElement => cy.get('#input-submit')
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 }

--- a/integration_tests/pages/subjectId.ts
+++ b/integration_tests/pages/subjectId.ts
@@ -14,4 +14,6 @@ export default class SubjectIdPage extends Page {
   continueButton = (): PageElement => cy.get('#subject-id-continue')
 
   errorSummaryBox = (): PageElement => cy.get('.govuk-error-summary')
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 }

--- a/server/views/pages/inputs.njk
+++ b/server/views/pages/inputs.njk
@@ -12,8 +12,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "../components/datepicker/macro.njk" import hmppsDatepicker %}
-
-
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
 
@@ -51,6 +50,11 @@
     ]
   }) }}
 {% endif %}
+
+{{ govukBackLink({
+  text: "Back",
+  href: "/subject-id"
+}) }}
 
 <h1>Enter details</h1>
 <form action="/inputs" method="post">

--- a/server/views/pages/serviceselection.njk
+++ b/server/views/pages/serviceselection.njk
@@ -4,6 +4,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "../components/multiselect.njk" import multiSelect %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
 {% block content %}
 
 {% if selectedServicesError %}
@@ -21,6 +23,11 @@
     ]
   }) }}
 {% endif %}
+
+{{ govukBackLink({
+  text: "Back",
+  href: "/inputs"
+}) }}
 
 <form action="/service-selection" method="post">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/server/views/pages/subjectid.njk
+++ b/server/views/pages/subjectid.njk
@@ -3,13 +3,18 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
 
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+
+      {{ govukBackLink({
+        text: "Back",
+        href: "/"
+      }) }}
 
       {% if subjectIdError %}
         {% set showErrors = true %}


### PR DESCRIPTION
## Context

User research suggested that users might prefer to have the option to navigate backwards in our user journey using back links. 

## Changes proposed in this PR

- This PR [adds back links](https://dsdmoj.atlassian.net/browse/SR-167) to the relevant pages of the Request a SAR Report user journey. 