### PR TITLE
Update wording on confirmation page

### DIFF
--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -12,9 +12,8 @@
 
     <section id="next-steps">
       <h2 class="govuk-heading-m">What happens next</h2>
-      <p class="govuk-body">You can check on the progress of this report and view it after completion on the <a href="/reports">completed reports</a> page.</p>
-      <p class="govuk-body">You will not get an email notification about this report.</p>
+      <p class="govuk-body">You can check on the progress of this report and view it after completion on the reports page.</p>
     </section>
-    <a href="/reports" class="govuk-body govuk-link" id="view-reports">View completed reports.</a>
+    <a href="/reports" class="govuk-body govuk-link" id="view-reports">View all reports.</a>
 
   {% endblock %}


### PR DESCRIPTION
## Context
User research sessions revealed some confusion about the wording on the confirmation screen.

## Changes proposed in this PR
[Update wording](https://dsdmoj.atlassian.net/browse/SR-171), specifically:
- Remove wording around receiving an email
- Update ‘view completed reports’ to ‘view all reports’
- Remove duplicate link