### PR TITLE
Clear session data after confirmation

### DIFF
--- a/server/controllers/confirmationController.test.ts
+++ b/server/controllers/confirmationController.test.ts
@@ -20,13 +20,30 @@ describe('getConfirmation', () => {
         },
       },
     }
+
     await ConfirmationController.getConfirmation(req, res)
+
     expect(res.render).toHaveBeenCalled()
     expect(res.render).toBeCalledWith(
       'pages/confirmation',
       expect.objectContaining({
-        caseReference: req.session.userData.caseReference,
+        caseReference: 'ExampleCaseReference',
       }),
     )
+  })
+
+  test('clears user data from session', async () => {
+    const req: Request = {
+      // @ts-expect-error stubbing session
+      session: {
+        userData: {
+          caseReference: 'ExampleCaseReference',
+        },
+      },
+    }
+
+    await ConfirmationController.getConfirmation(req, res)
+
+    expect(req.session.userData).toEqual({})
   })
 })

--- a/server/controllers/confirmationController.ts
+++ b/server/controllers/confirmationController.ts
@@ -7,5 +7,7 @@ export default class ConfirmationController {
     res.render('pages/confirmation', {
       caseReference: userData.caseReference,
     })
+
+    req.session.userData = {}
   }
 }


### PR DESCRIPTION
### Context

Previously, if a user wanted to immediately request another report, all the outdated data from their previous request would still be saved throughout the form. Additionally, users could press the browser’s back button to get to previous pages, and may erroneously resubmit a request for the same report.

### Changes proposed in this PR

This PR clears user data from the session once the confirmation screen is displayed.