### PR TITLE
Update report download to customise file name

### DIFF
--- a/server/controllers/reportDownloadController.test.ts
+++ b/server/controllers/reportDownloadController.test.ts
@@ -1,0 +1,36 @@
+import type { Request, Response } from 'express'
+import ReportDownloadController from './reportDownloadController'
+import formatDate from '../utils/dateHelpers'
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('getReport', () => {
+  test('creates a fileName from request query parameters', async () => {
+    // @ts-expect-error stubbing res.set
+    const res: Response = {
+      set: jest.fn(),
+      send: jest.fn(),
+    }
+    const req: Request = {
+      // @ts-expect-error stubbing session
+      session: {},
+      query: {
+        id: 'mock-file-ID',
+        sarCaseReference: 'mock-sar-case-reference',
+        subjectId: 'mock-subject-ID',
+      },
+    }
+    const next = jest.fn()
+    const date = formatDate(new Date().toISOString(), 'short')
+
+    await ReportDownloadController.getReport(req, res, next)
+
+    expect(res.set).toHaveBeenCalled()
+    expect(res.set).toHaveBeenCalledWith(
+      'Content-Disposition',
+      `attachment;filename="subject-access-request-report-${date}-mock-sar-case-reference-mock-subject-ID"`,
+    )
+  })
+})

--- a/server/controllers/reportDownloadController.ts
+++ b/server/controllers/reportDownloadController.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express'
+import getReport from '../services/report'
+import formatDate from '../utils/dateHelpers'
+
+export default class ReportDownloadController {
+  static getReport(req: Request, res: Response, next: NextFunction) {
+    const fileId = req.query.id as string
+    const sarCaseReference = req.query.sarCaseReference as string
+    const subjectId = req.query.subjectId as string
+
+    if (!fileId || !subjectId || !sarCaseReference) {
+      throw new Error('Report ID, subject ID or SAR case reference number missing.')
+    }
+
+    const downloadDate = formatDate(new Date().toISOString(), 'short')
+
+    res.set(
+      'Content-Disposition',
+      `attachment;filename="subject-access-request-report-${downloadDate}-${sarCaseReference}-${subjectId}"`,
+    )
+
+    getReport(req, res, next, fileId)
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,7 +7,7 @@ import SummaryController from '../controllers/summaryController'
 import ConfirmationController from '../controllers/confirmationController'
 import SubjectIdController from '../controllers/subjectIdController'
 import ReportsController from '../controllers/reportsController'
-import getReport from '../services/report'
+import ReportDownloadController from '../controllers/reportDownloadController'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(service: Services): Router {
@@ -30,17 +30,13 @@ export default function routes(service: Services): Router {
 
   get('/service-selection', ServiceSelectionController.getServices)
 
-  router.post('/service-selection', ServiceSelectionController.selectServices)
+  post('/service-selection', ServiceSelectionController.selectServices)
 
   get('/confirmation', ConfirmationController.getConfirmation)
 
   get('/reports', ReportsController.getReports)
 
-  router.get('/download-report/:fileId', (req, res, next) => {
-    const {
-      params: { fileId },
-    } = req
-    getReport(req, res, next, fileId)
-  })
+  get('/download-report/report', ReportDownloadController.getReport)
+
   return router
 }

--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -69,7 +69,7 @@
                     <td class="govuk-table__cell">{{report.dateOfRequest}}</td>
                     <td class="govuk-table__cell">{{report.sarCaseReference}}</td>
                     <td class="govuk-table__cell">{{report.subjectId}}</td>
-                    <td class="govuk-table__cell"><a href="/download-report/{{report.uuid}}" download class="govuk-body govuk-link" /a>View report</td>
+                    <td class="govuk-table__cell"><a href="/download-report/report?id={{report.uuid}}&sarCaseReference={{report.sarCaseReference}}&subjectId={{report.subjectId}}" download class="govuk-body govuk-link" /a>View report</td>
                     <td class="govuk-table__cell">{{report.lastDownloaded}}</td>
                 </tr>
           {% else %}


### PR DESCRIPTION
This PR adds a customised file name to the SAR PDF on download. Changes include:
- Extracting the download report functionality into a separate controller
- Adding error handling for missing fields, though this should not be possible given checks done before SARs can be entered into the database
- The creation of a filename from details of the SAR report and the date of download

The below image show this working locally:
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/cb7bf78d-7dcc-43ef-81bb-f2bab96b4b98">
