### PR TITLE
Fix bug where session data persists across requests

### DIFF
--- a/server/controllers/confirmationController.test.ts
+++ b/server/controllers/confirmationController.test.ts
@@ -39,11 +39,13 @@ describe('getConfirmation', () => {
         userData: {
           caseReference: 'ExampleCaseReference',
         },
+        selectedList: [{ id: '1', text: 'service1' }],
       },
     }
 
     await ConfirmationController.getConfirmation(req, res)
 
     expect(req.session.userData).toEqual({})
+    expect(req.session.selectedList).toEqual([])
   })
 })

--- a/server/controllers/confirmationController.ts
+++ b/server/controllers/confirmationController.ts
@@ -9,5 +9,6 @@ export default class ConfirmationController {
     })
 
     req.session.userData = {}
+    req.session.selectedList = []
   }
 }


### PR DESCRIPTION
A bug occurred because, whilst user data was cleared from the session at the confirmation page, the selected services were not. This meant that users who went to submit a second SAR report request would find data from their previous request still populating fields.


This PR clears this data when the confirmation page is reached.


https://github.com/user-attachments/assets/59534528-a81a-424b-afdc-13bacf4880e2

