### PR TITLE
Fix row separator in reports table

### DIFF
--- a/server/views/pages/reports.njk
+++ b/server/views/pages/reports.njk
@@ -78,6 +78,7 @@
                     <td class="govuk-table__cell">{{report.sarCaseReference}}</td>
                     <td class="govuk-table__cell">{{report.subjectId}}</td>
                     <td class="govuk-table__cell">{{report.status}}</td>
+                    <td class="govuk-table__cell">{{report.lastDownloaded}}</td>
                 </tr>
           {% endif %}
             {% endfor %}


### PR DESCRIPTION
## Context
When a report had not previously been downloaded (and so did not have a 'last downloaded' date-time), the row separator line did not extend across the full table width. This PR fixes that.

Before:
![image](https://github.com/user-attachments/assets/9414b146-769f-4a7b-94ab-ed8363c1801c)


After:
![image](https://github.com/user-attachments/assets/d3058c77-d27f-46f7-b536-9e340d117b6b)


