### PR TITLE
Add terms and conditions to footer

### DIFF
--- a/integration_tests/e2e/terms.cy.ts
+++ b/integration_tests/e2e/terms.cy.ts
@@ -1,0 +1,38 @@
+import Page from '../pages/page'
+import AuthSignInPage from '../pages/authSignIn'
+import IndexPage from '../pages/homepage'
+import TermsPage from '../pages/terms'
+
+context('Terms', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubManageUser')
+  })
+
+  it('Redirects to auth if requested by unauthenticated user', () => {
+    cy.visit('/terms')
+    Page.verifyOnPage(AuthSignInPage)
+  })
+
+  it('Renders for authenticated users', () => {
+    cy.signIn()
+    cy.visit('/terms')
+  })
+
+  it('Displays all necessary components', () => {
+    cy.signIn()
+    cy.visit('/terms')
+    const termsAndConditionsPage = Page.verifyOnPage(TermsPage)
+    termsAndConditionsPage.termsAndConditions().should('exist')
+    termsAndConditionsPage.linkToHomepage().should('exist')
+  })
+
+  it('redirects to homepage when back link is clicked', () => {
+    cy.signIn()
+    cy.visit('/terms')
+    const termsAndConditionsPage = Page.verifyOnPage(TermsPage)
+    termsAndConditionsPage.linkToHomepage().click()
+    Page.verifyOnPage(IndexPage)
+  })
+})

--- a/integration_tests/pages/terms.ts
+++ b/integration_tests/pages/terms.ts
@@ -1,0 +1,11 @@
+import Page, { PageElement } from './page'
+
+export default class TermsPage extends Page {
+  constructor() {
+    super('Terms and conditions')
+  }
+
+  termsAndConditions = (): PageElement => cy.get('.terms-and-conditions-text')
+
+  linkToHomepage = (): PageElement => cy.get('.govuk-back-link')
+}

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -167,3 +167,16 @@ describe('GET /reports', () => {
       })
   })
 })
+
+describe('GET /terms', () => {
+  it('should render terms and conditions page', () => {
+    return request(app)
+      .get('/terms')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain(
+          'Access to, and use of, this system is restricted to authorized Prison-NOMIS account users only.',
+        )
+      })
+  })
+})

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -38,5 +38,9 @@ export default function routes(service: Services): Router {
 
   get('/download-report/report', ReportDownloadController.getReport)
 
+  get('/terms', (req, res, next) => {
+    res.render('pages/terms')
+  })
+
   return router
 }

--- a/server/views/pages/terms.njk
+++ b/server/views/pages/terms.njk
@@ -1,0 +1,43 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+
+{% block content %}
+
+<div class="govuk-grid-column-two-thirds">
+
+    {{ govukBackLink({
+        text: "Home",
+        href: "/"
+    }) }}
+
+    <h1 class="govuk-heading-l">Terms and conditions</h1>
+    <div class="terms-and-conditions-text"></div>
+    <p class="govuk-body">
+        Access to, and use of, this system is restricted to authorized Prison-NOMIS account users only.
+    </p>
+    <p class="govuk-body">
+        All users must read and conform to the Prison-NOMIS Security Operating Procedures, together with any
+        additional Security and IT policies from within your organisation which may also apply.
+    </p>
+    <p class="govuk-body">
+        You are reminded that this system is protected by a security framework and that all data entered into
+        Prison-NOMIS is potentially liable to legal disclosure under the Data Protection Act and/or the Freedom
+        of Information Act.
+    </p>
+    <p class="govuk-body">
+        All activities undertaken with regard to the Prison-NOMIS system must comply with the requirements of
+        the Computer Misuse Act and other relevant data legislation.
+    </p>
+    <p class="govuk-body">
+        Only accurate and relevant information must be entered in Prison-NOMIS.
+    </p>
+    <p class="govuk-body">
+        Unauthorised access or attempts to alter, destroy, damage, disclose or otherwise interfere with the data
+        in Prison-NOMIS could result in disciplinary proceedings and / or criminal prosecution.
+    </p>
+
+</div>
+
+
+{% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 {% extends "govuk/template.njk" %}
 
 {% block head %}
@@ -21,6 +22,20 @@
 {% block bodyStart %}
 {% endblock %}
 
+{% block footer %}
+{{ govukFooter({
+  meta: {
+    items: [
+      {
+        href: "/terms",
+        text: "Terms and conditions"
+      }
+    ]
+  }
+}) }}
+
+{% endblock %}
+
 {% block bodyEnd %}
   {# Run JavaScript at end of the
   <body>, to avoid blocking the initial render. #}
@@ -33,4 +48,5 @@
   <script src="/assets/js/moj-init.js"></script>  
   <script src="/assets/moj/all.js"></script>
   <script src="/assets/datepicker.js"></script>
+
 {% endblock %}


### PR DESCRIPTION
This PR adds a terms and conditions page, which is linked via the footer.


https://github.com/user-attachments/assets/8b1a36d8-40b4-485c-b748-5343f2843762

