### PR TITLE
PI-2524 Add MOJ Cloud Platform to IP allow list in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,5 +17,10 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     SAR_ENDPOINT_URL: "https://subject-access-request-api-dev.hmpps.service.justice.gov.uk"
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
This is required for the Probation Integration end-to-end tests, which recently started getting 403 errors - see https://ministryofjustice.github.io/hmpps-probation-integration-e2e-tests/playwright-report/test/main/2024-10-07/aa99ad86106bef6cbe7b6f9d345d554c1db4d00c/11219099436/1/#?testId=02f5bf2f907e3e362b2c-e79ba1340029aa084b6c