### PR TITLE
 HAAR-5184: temp rollback validation feature to unblock env while investigating

### DIFF
--- a/integration_tests/specs/registerTemplateUpload.spec.ts
+++ b/integration_tests/specs/registerTemplateUpload.spec.ts
@@ -106,21 +106,22 @@ test.describe('Register template upload file', () => {
     await expect(uploadPage.versionTable).toBeVisible()
   })
 
-  test('Displays error when template file is not valid mustache syntax', async ({ page }) => {
-    await registerTemplateUpload(page, {})
-    const uploadPage = await verifyOnPage(page, RegisterTemplateUploadPage)
-
-    await uploadPage.selectTemplateFile('invalid-template.mustache')
-    await uploadPage.continue()
-
-    await expect(uploadPage.header).toHaveText('Upload template for Service One')
-    await expect(uploadPage.errorSummary).toContainText('Invalid mustache template:')
-    await expect(uploadPage.errorSummary).toContainText('Unopened section "uploads" at')
-    await expect(uploadPage.notificationBanner).not.toBeVisible()
-    await expect(uploadPage.templateFileInputError).toContainText('Invalid mustache template:')
-    await expect(uploadPage.templateFileInputError).toContainText('Unopened section "uploads" at')
-    await expect(uploadPage.versionTable).toBeVisible()
-  })
+  // TODO TEMP ROLLBACK
+  // test('Displays error when template file is not valid mustache syntax', async ({ page }) => {
+  //   await registerTemplateUpload(page, {})
+  //   const uploadPage = await verifyOnPage(page, RegisterTemplateUploadPage)
+  //
+  //   await uploadPage.selectTemplateFile('invalid-template.mustache')
+  //   await uploadPage.continue()
+  //
+  //   await expect(uploadPage.header).toHaveText('Upload template for Service One')
+  //   await expect(uploadPage.errorSummary).toContainText('Invalid mustache template:')
+  //   await expect(uploadPage.errorSummary).toContainText('Unopened section "uploads" at')
+  //   await expect(uploadPage.notificationBanner).not.toBeVisible()
+  //   await expect(uploadPage.templateFileInputError).toContainText('Invalid mustache template:')
+  //   await expect(uploadPage.templateFileInputError).toContainText('Unopened section "uploads" at')
+  //   await expect(uploadPage.versionTable).toBeVisible()
+  // })
 
   test('Redirects to confirmation when continue with file selected', async ({ page }) => {
     await registerTemplateUpload(page, {})

--- a/server/controllers/registerTemplateUploadController.test.ts
+++ b/server/controllers/registerTemplateUploadController.test.ts
@@ -102,7 +102,8 @@ describe('uploadTemplate', () => {
 
     await RegisterTemplateUploadController.uploadTemplate(req, res)
 
-    expect(templateVersionsService.validateTemplateBody).toHaveBeenCalledWith('testfile\n')
+    // TODO TEMP ROLLBACK
+    // expect(templateVersionsService.validateTemplateBody).toHaveBeenCalledWith('testfile\n')
     expect(res.redirect).toHaveBeenCalledWith('/register-template/confirmation')
     expect(req.session.templateName).toEqual('myfile.mustache')
     expect(req.session.templateFileBase64).toEqual(templateBase64)
@@ -152,24 +153,25 @@ describe('uploadTemplate', () => {
     )
   })
 
-  test('renders upload page with error when file uploaded is not valid mustache file', async () => {
-    templateVersionsService.validateTemplateBody = jest.fn().mockReturnValue(Error('<mustache error description here>'))
-
-    const invalidTemplate = 'Hello {{#name}}'
-    const encoded = Buffer.from(invalidTemplate, 'utf-8').toString('base64')
-
-    req.file.buffer = Buffer.from(encoded, 'base64')
-    req.file.originalname = 'myfile.mustache'
-
-    await RegisterTemplateUploadController.uploadTemplate(req, res)
-
-    expect(templateVersionsService.validateTemplateBody).toHaveBeenCalledWith(invalidTemplate)
-
-    expect(res.render).toHaveBeenCalledWith(
-      'pages/registerTemplate/upload',
-      expect.objectContaining({
-        uploadError: 'Invalid mustache template: <mustache error description here>',
-      }),
-    )
-  })
+  // TODO TEMP ROLLBACK
+  // test('renders upload page with error when file uploaded is not valid mustache file', async () => {
+  //   templateVersionsService.validateTemplateBody = jest.fn().mockReturnValue(Error('<mustache error description here>'))
+  //
+  //   const invalidTemplate = 'Hello {{#name}}'
+  //   const encoded = Buffer.from(invalidTemplate, 'utf-8').toString('base64')
+  //
+  //   req.file.buffer = Buffer.from(encoded, 'base64')
+  //   req.file.originalname = 'myfile.mustache'
+  //
+  //   await RegisterTemplateUploadController.uploadTemplate(req, res)
+  //
+  //   expect(templateVersionsService.validateTemplateBody).toHaveBeenCalledWith(invalidTemplate)
+  //
+  //   expect(res.render).toHaveBeenCalledWith(
+  //     'pages/registerTemplate/upload',
+  //     expect.objectContaining({
+  //       uploadError: 'Invalid mustache template: <mustache error description here>',
+  //     }),
+  //   )
+  // })
 })

--- a/server/controllers/registerTemplateUploadController.ts
+++ b/server/controllers/registerTemplateUploadController.ts
@@ -53,17 +53,18 @@ export default class RegisterTemplateUploadController {
       return
     }
 
-    const validationErr = templateVersionsService.validateTemplateBody(
-      RegisterTemplateUploadController.getTemplateBody(buffer),
-    )
-    if (validationErr != null) {
-      res.render('pages/registerTemplate/upload', {
-        versionList,
-        selectedProduct,
-        uploadError: `Invalid mustache template: ${validationErr.message.trim()}`,
-      })
-      return
-    }
+    // TODO TEMP ROLLBACK.
+    // const validationErr = templateVersionsService.validateTemplateBody(
+    //   RegisterTemplateUploadController.getTemplateBody(buffer),
+    // )
+    // if (validationErr != null) {
+    //   res.render('pages/registerTemplate/upload', {
+    //     versionList,
+    //     selectedProduct,
+    //     uploadError: `Invalid mustache template: ${validationErr.message.trim()}`,
+    //   })
+    //   return
+    // }
 
     req.session.templateName = originalname
     req.session.templateFileBase64 = buffer.toString('base64')


### PR DESCRIPTION
The validation is not correctly handling handlebars syntax and blocking uploads. Temp disable new feature to unblock env while I investigate a solution.